### PR TITLE
DIVAFT: Unlock (Extra) Extreme

### DIFF
--- a/PATCHES/HatsuneMiku_ProjectDIVAFutureTone.xml
+++ b/PATCHES/HatsuneMiku_ProjectDIVAFutureTone.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA08026</ID>
+        <ID>CUSA08053</ID>
+        <ID>CUSA06093</ID>
+        <ID>CUSA06211</ID>
+        <ID>CUSA05030</ID>
+        <ID>CUSA03828</ID>
+    </TitleID>
+    <Metadata Title="Hatsune Miku: Project DIVA Future Tone"
+              Name="Unlock (Extra) Extreme"
+              Author="M&amp;M, Stewie10"
+              PatchVer="1.0"
+              AppVer="mask"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="mask" Address="8A 87 19 01 00 00 C3" Value="b001c390909090"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
Allows you to access the (Extra) Extreme difficulty even if you haven't beaten Hard.

(look at difficulty select in top right)
Before:
![2024-09-03_19-49-57_shadPS4](https://github.com/user-attachments/assets/fc1736df-2114-4d9a-add7-8719de17c1d6)
After:
![2024-09-03_19-50-45_shadPS4](https://github.com/user-attachments/assets/4864c681-f448-4386-8667-44a564673b49)

Credits: @Stewie10 for finding the variable/flag