### PR TITLE
feat: Add 900p resolution to Bloodborne.xml patch

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1233,6 +1233,39 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
+              Name="Resolution Patch (900p)"
+              Author="LeDragoX"
+              PatchVer="1.0"
+              AppVer="01.09"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000640"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000384"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne"
               Name="Resolution Patch (864x486)"
               Note="HP bars are often invisible."
               Author="xzy"


### PR DESCRIPTION
Add 900p resolution to Bloodborne, I felt this resolution was missing.