### PR TITLE
Added the 60 fps sound workaround

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -59,6 +59,11 @@
             <Line Type="bytes" Address="0x024EE2A9" Value="9090909090"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Bloodborne" Name="Skip Sound on Crash" Author="proteh" PatchVer="1.0" AppVer="01.09" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x0000204E" Value="0x00000001"/>
+        </PatchList>
+    </Metadata>
     <Metadata Title="Bloodborne"
               Name="60 FPS (With Deltatime)"
               Note="You may encounter softlock during Laurence (optional DLC boss) cinematic.\nDisable patch to progress."


### PR DESCRIPTION
Adds the disappearing sound workaround as a patch for Bloodborne from [this Discord message](https://discord.com/channels/1080089157554155590/1258386683691274361/1314175180045811744). Edit: This will not work since the byte to change is not in eboot.bin, but if anyone knows how to access the savedata from the patches, feel free to do it.