### PR TITLE
Fix Bloodborne 60fps patch most cloth physics (thanks Kyo)

### DIFF
--- a/CHEATS/CUSA00207_01.09.json
+++ b/CHEATS/CUSA00207_01.09.json
@@ -18,7 +18,7 @@
     },
     "mods": [
         {
-            "name": "Infinite  BloodEcho",
+            "name": "Infinite BloodEcho",
             "type": "checkbox",
             "memory": [
                 {

--- a/CHEATS/CUSA00208_01.09.json
+++ b/CHEATS/CUSA00208_01.09.json
@@ -18,7 +18,7 @@
     },
     "mods": [
         {
-            "name": "Infinite  BloodEcho",
+            "name": "Infinite BloodEcho",
             "type": "checkbox",
             "memory": [
                 {

--- a/CHEATS/CUSA00900_01.09.json
+++ b/CHEATS/CUSA00900_01.09.json
@@ -18,7 +18,7 @@
     },
     "mods": [
         {
-            "name": "Infinite  BloodEcho",
+            "name": "Infinite BloodEcho",
             "type": "checkbox",
             "memory": [
                 {

--- a/CHEATS/CUSA01363_01.09.json
+++ b/CHEATS/CUSA01363_01.09.json
@@ -18,7 +18,7 @@
     },
     "mods": [
         {
-            "name": "Infinite  BloodEcho",
+            "name": "Infinite BloodEcho",
             "type": "checkbox",
             "memory": [
                 {

--- a/CHEATS/CUSA03023_01.09.json
+++ b/CHEATS/CUSA03023_01.09.json
@@ -18,7 +18,7 @@
     },
     "mods": [
         {
-            "name": "Infinite  BloodEcho",
+            "name": "Infinite BloodEcho",
             "type": "checkbox",
             "memory": [
                 {

--- a/CHEATS/CUSA03173_01.09.json
+++ b/CHEATS/CUSA03173_01.09.json
@@ -18,7 +18,7 @@
     },
     "mods": [
         {
-            "name": "Infinite  BloodEcho",
+            "name": "Infinite BloodEcho",
             "type": "checkbox",
             "memory": [
                 {

--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -62,7 +62,7 @@
     <Metadata Title="Bloodborne"
               Name="60 FPS (With Deltatime)"
               Note="You may encounter softlock during Laurence (optional DLC boss) cinematic.\nDisable patch to progress."
-              Author="Lance McDonald (manfightdragon)"
+              Author="Lance McDonald (manfightdragon), Kyo"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -70,7 +70,7 @@
             <Line Type="bytes" Address="0x00fbc40f" Value="eb1d"/>
             <Line Type="bytes" Address="0x013d2e16" Value="eb19"/>
             <Line Type="bytes" Address="0x013d2e18" Value="4156"/>
-            <Line Type="bytes" Address="0x013d2e1a" Value="41c746080000003f"/>
+            <Line Type="bytes" Address="0x013d2e1a" Value="41c746080000803f"/>
             <Line Type="bytes" Address="0x013d2e22" Value="c4c17a5e4608"/>
             <Line Type="bytes" Address="0x013d2e28" Value="415e"/>
             <Line Type="bytes" Address="0x013d2e2a" Value="e933070000"/>


### PR DESCRIPTION
Patch modified by Kyo, has been widely tested and proven effective
https://discord.com/channels/1080089157554155590/1245616678021234768/1292482525674999818

> 60 FPS Cloth Physics HOW TO:
>
> Change "41c746080000003f" to "41c746080000803f" under the 60 fps (With Deltatime) patch.
>
> My assumption was this is IEEE 754 the floating point value for 1.0 (3F800000)
The value was set to 0.5 (3F000000) doubling cloth speed instead of normalizing it when everything was increased to 60fps, and little-endian reversed the order to look like 0000003F which you change to 0000803F
>
> Keep in mind, while this does fix most cloth physics, there seems to be another value somewhere still affecting others I've yet to find/change/fix.
The two videos show 60 vs 30 fps cloth physics with the change. 