### PR TITLE
Highest Possible Resolution No crash (60 fps Cloth physics Fix)

### DIFF
--- a/PATCHES/Bloodborne
+++ b/PATCHES/Bloodborne
@@ -1,0 +1,2079 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA00900</ID>
+        <ID>CUSA00207</ID>
+        <ID>CUSA03173</ID>
+        <ID>CUSA03023</ID>
+        <ID>CUSA00208</ID>
+        <ID>CUSA01363</ID>
+    </TitleID>
+    <Metadata Title="Bloodborne" 
+              Name="Skip Intro" 
+              Author="illusion" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x04d99138" Value="0x00000000"/>
+            <Line Type="bytes32" Address="0x04d99154" Value="0x00000000"/>
+            <Line Type="bytes32" Address="0x04d9916e" Value="0x00000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="30 FPS Fix (Proper Frame Pacing)" 
+              Note="Caps framerate to 30 with proper frame pacing." 
+              Author="illusion, Lance McDonald (manfightdragon)" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="float32" Address="0x02434883" Value="0.016666667"/>
+            <Line Type="bytes" Address="0x02ad61df" Value="be010000004989dc9090909090"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Disable Chromatic Aberration" 
+              Author="illusion" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0269faa8" Value="c783ac000000000000009090"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Disable Motion Blur" 
+              Author="illusion" 
+              PatchVer="1.0" 
+              AppVer="01.09"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x026a057b" Value="eb16"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Disable HTTP Requests" 
+              Author="bloo" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0227E2F0" Value="9090909090"/>
+            <Line Type="bytes" Address="0x023E4D96" Value="9090909090"/>
+            <Line Type="bytes" Address="0x024EE2A9" Value="9090909090"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="60 FPS (With Deltatime)" 
+              Note="You may encounter softlock during Laurence (optional DLC boss) cinematic.\nDisable patch to progress."                                                                 
+              Author="Lance McDonald (manfightdragon)" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x00fbc40f" Value="eb1d"/>
+            <Line Type="bytes" Address="0x013d2e16" Value="eb19"/>
+            <Line Type="bytes" Address="0x013d2e18" Value="4156"/>
+            <Line Type="bytes" Address="0x013d2e1a" Value="41c746080000C03F"/>
+            <Line Type="bytes" Address="0x013d2e22" Value="c4c17a5e4608"/>
+            <Line Type="bytes" Address="0x013d2e28" Value="415e"/>
+            <Line Type="bytes" Address="0x013d2e2a" Value="e933070000"/>
+            <Line Type="bytes" Address="0x013d2e2f" Value="90"/>
+            <Line Type="bytes" Address="0x013d2e30" Value="90"/>
+            <Line Type="bytes" Address="0x013d3557" Value="c4c17a104608"/>
+            <Line Type="bytes" Address="0x013d355d" Value="e9b6f8ffff"/>
+            <Line Type="bytes" Address="0x01bf9b71" Value="e933010000"/>
+            <Line Type="bytes" Address="0x01bf9b76" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9b77" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ca9" Value="488d054868d403"/>
+            <Line Type="bytes" Address="0x01bf9cb0" Value="488b00"/>
+            <Line Type="bytes" Address="0x01bf9cb3" Value="8b8064020000"/>
+            <Line Type="bytes" Address="0x01bf9cb9" Value="8945b8"/>
+            <Line Type="bytes" Address="0x01bf9cbc" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cbd" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cbe" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cbf" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc0" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc1" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc2" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc3" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc4" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc5" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc6" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc7" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc8" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc9" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cca" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccb" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccc" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccd" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cce" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccf" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cd0" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cd1" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cd2" Value="e9a1feffff"/>
+            <Line Type="bytes" Address="0x021bc181" Value="488d3d70437803"/>
+            <Line Type="bytes" Address="0x021bc188" Value="488b3f"/>
+            <Line Type="bytes" Address="0x021bc18b" Value="c5fa598764020000"/>
+            <Line Type="bytes" Address="0x021bc193" Value="90"/>
+            <Line Type="bytes" Address="0x021bc194" Value="90"/>
+            <Line Type="bytes" Address="0x021bc195" Value="90"/>
+            <Line Type="bytes" Address="0x021bc196" Value="90"/>
+            <Line Type="bytes" Address="0x021bc197" Value="90"/>
+            <Line Type="bytes" Address="0x021bc198" Value="90"/>
+            <Line Type="bytes" Address="0x021bc199" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19a" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19b" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19c" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19d" Value="e96e010000"/>
+            <Line Type="bytes" Address="0x021bc308" Value="e974feffff"/>
+            <Line Type="bytes" Address="0x021bc30d" Value="90"/>
+            <Line Type="bytes" Address="0x021bc30e" Value="90"/>
+            <Line Type="bytes" Address="0x021bc30f" Value="90"/>
+            <Line Type="bytes" Address="0x02377cea" Value="eb24"/>
+            <Line Type="bytes" Address="0x02377cec" Value="488d1d05885c03"/>
+            <Line Type="bytes" Address="0x02377cf3" Value="488b1b"/>
+            <Line Type="bytes" Address="0x02377cf6" Value="c5fa108364020000"/>
+            <Line Type="bytes" Address="0x02377cfe" Value="90"/>
+            <Line Type="bytes" Address="0x02377cff" Value="90"/>
+            <Line Type="bytes" Address="0x02377d00" Value="90"/>
+            <Line Type="bytes" Address="0x02377d01" Value="90"/>
+            <Line Type="bytes" Address="0x02377d02" Value="90"/>
+            <Line Type="bytes" Address="0x02377d03" Value="90"/>
+            <Line Type="bytes" Address="0x02377d04" Value="90"/>
+            <Line Type="bytes" Address="0x02377d05" Value="90"/>
+            <Line Type="bytes" Address="0x02377d06" Value="90"/>
+            <Line Type="bytes" Address="0x02377d07" Value="90"/>
+            <Line Type="bytes" Address="0x02377d08" Value="90"/>
+            <Line Type="bytes" Address="0x02377d09" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0a" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0b" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0c" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0d" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0e" Value="eb42"/>
+            <Line Type="bytes" Address="0x02377d48" Value="eba2"/>
+            <Line Type="bytes" Address="0x02418e3d" Value="8b8364020000"/>
+            <Line Type="bytes" Address="0x02418e43" Value="8945c8"/>
+            <Line Type="bytes" Address="0x02418e46" Value="90"/>
+            <Line Type="bytes" Address="0x02418e47" Value="90"/>
+            <Line Type="bytes" Address="0x02418e48" Value="90"/>
+            <Line Type="bytes" Address="0x02418e49" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4a" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4b" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4c" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4d" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4e" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4f" Value="90"/>
+            <Line Type="bytes" Address="0x02418e50" Value="90"/>
+            <Line Type="bytes" Address="0x02418e51" Value="90"/>
+            <Line Type="bytes" Address="0x02418e52" Value="90"/>
+            <Line Type="bytes" Address="0x02418e53" Value="90"/>
+            <Line Type="bytes" Address="0x02418e54" Value="90"/>
+            <Line Type="bytes" Address="0x02418e55" Value="90"/>
+            <Line Type="bytes" Address="0x02418e56" Value="90"/>
+            <Line Type="bytes" Address="0x02418e57" Value="90"/>
+            <Line Type="bytes" Address="0x02418e58" Value="90"/>
+            <Line Type="bytes" Address="0x02418e59" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5a" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5b" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5c" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5d" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5e" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5f" Value="90"/>
+            <Line Type="bytes" Address="0x02418e60" Value="90"/>
+            <Line Type="bytes" Address="0x02418e61" Value="90"/>
+            <Line Type="bytes" Address="0x02418e62" Value="90"/>
+            <Line Type="bytes" Address="0x02418e63" Value="90"/>
+            <Line Type="bytes" Address="0x02418e64" Value="488d05a5765203"/>
+            <Line Type="bytes" Address="0x0243487e" Value="41c74424188988883c"/>
+            <Line Type="bytes" Address="0x02434887" Value="48b90000000001000000"/>
+            <Line Type="bytes" Address="0x02483ec1" Value="c3"/>
+            <Line Type="bytes" Address="0x02483ec2" Value="90"/>
+            <Line Type="bytes" Address="0x02483ec3" Value="90"/>
+            <Line Type="bytes" Address="0x02483ec4" Value="90"/>
+            <Line Type="bytes" Address="0x02483ec5" Value="90"/>
+            <Line Type="bytes" Address="0x02715d71" Value="e881090000"/>
+            <Line Type="bytes" Address="0x02715d76" Value="90"/>
+            <Line Type="bytes" Address="0x02715d77" Value="90"/>
+            <Line Type="bytes" Address="0x02715d78" Value="90"/>
+            <Line Type="bytes" Address="0x02fbf178" Value="4831c0c3"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Force Enable Old Hunters DLC" 
+              Note="Also bypass save data requirement from users that don't have DLC on their console but using save from user that does." 
+              Author="Lance McDonald (manfightdragon)" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x023b6d20" Value="b801000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Restore Debug Camera" 
+              Note="Hold Action (X button) and press the L3 button to cycle through freecam modes." 
+              Author="Lance McDonald (manfightdragon)" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01972998" Value="7416"/>
+            <Line Type="bytes" Address="0x0197299a" Value="48394a20"/>
+            <Line Type="bytes" Address="0x0197299e" Value="4889c1"/>
+            <Line Type="bytes" Address="0x019729a1" Value="7f03"/>
+            <Line Type="bytes" Address="0x019729a3" Value="4889d1"/>
+            <Line Type="bytes" Address="0x019729a6" Value="4839c1"/>
+            <Line Type="bytes" Address="0x019729a9" Value="7405"/>
+            <Line Type="bytes" Address="0x019729ab" Value="e979094700"/>
+            <Line Type="bytes" Address="0x019729b0" Value="90"/>
+            <Line Type="bytes" Address="0x019729b1" Value="90"/>
+            <Line Type="bytes" Address="0x019729b2" Value="90"/>
+            <Line Type="bytes" Address="0x019729b3" Value="31f6"/>
+            <Line Type="bytes" Address="0x019729b5" Value="e8f63ad9ff"/>
+            <Line Type="bytes" Address="0x019729ba" Value="e972094700"/>
+            <Line Type="bytes" Address="0x01de3328" Value="c3"/>
+            <Line Type="bytes" Address="0x01de3329" Value="c6413001"/>
+            <Line Type="bytes" Address="0x01de332d" Value="488b4128"/>
+            <Line Type="bytes" Address="0x01de3331" Value="90"/>
+            <Line Type="bytes" Address="0x01de3332" Value="90"/>
+            <Line Type="bytes" Address="0x01de3333" Value="90"/>
+            <Line Type="bytes" Address="0x01de3334" Value="90"/>
+            <Line Type="bytes" Address="0x01de3335" Value="90"/>
+            <Line Type="bytes" Address="0x01de3336" Value="90"/>
+            <Line Type="bytes" Address="0x01de3337" Value="50"/>
+            <Line Type="bytes" Address="0x01de3338" Value="be08000000"/>
+            <Line Type="bytes" Address="0x01de333d" Value="4889c7"/>
+            <Line Type="bytes" Address="0x01de3340" Value="e81be95aff"/>
+            <Line Type="bytes" Address="0x01de3345" Value="84c0"/>
+            <Line Type="bytes" Address="0x01de3347" Value="0f84ff000000"/>
+            <Line Type="bytes" Address="0x01de334d" Value="4180bc24c400000001"/>
+            <Line Type="bytes" Address="0x01de3356" Value="7416"/>
+            <Line Type="bytes" Address="0x01de3358" Value="41c68424c400000001"/>
+            <Line Type="bytes" Address="0x01de3361" Value="41c6855001000001"/>
+            <Line Type="bytes" Address="0x01de3369" Value="e929000000"/>
+            <Line Type="bytes" Address="0x01de336e" Value="4180bd5001000000"/>
+            <Line Type="bytes" Address="0x01de3376" Value="7413"/>
+            <Line Type="bytes" Address="0x01de3378" Value="41c6855001000000"/>
+            <Line Type="bytes" Address="0x01de3380" Value="41c68424c800000001"/>
+            <Line Type="bytes" Address="0x01de3389" Value="eb0c"/>
+            <Line Type="bytes" Address="0x01de338b" Value="49c78424c400000000000000"/>
+            <Line Type="bytes" Address="0x01de3397" Value="498b8c24d0000000"/>
+            <Line Type="bytes" Address="0x01de339f" Value="41807c244800"/>
+            <Line Type="bytes" Address="0x01de33a5" Value="0f844c000000"/>
+            <Line Type="bytes" Address="0x01de33ab" Value="c4c17828442450"/>
+            <Line Type="bytes" Address="0x01de33b2" Value="c5f8294110"/>
+            <Line Type="bytes" Address="0x01de33b7" Value="c4c17828442460"/>
+            <Line Type="bytes" Address="0x01de33be" Value="c5f8294120"/>
+            <Line Type="bytes" Address="0x01de33c3" Value="c4c17828442470"/>
+            <Line Type="bytes" Address="0x01de33ca" Value="c5f8294130"/>
+            <Line Type="bytes" Address="0x01de33cf" Value="c4c17828842480000000"/>
+            <Line Type="bytes" Address="0x01de33d9" Value="c5f8294140"/>
+            <Line Type="bytes" Address="0x01de33de" Value="498b8c24d0000000"/>
+            <Line Type="bytes" Address="0x01de33e6" Value="c4c17a1044244c"/>
+            <Line Type="bytes" Address="0x01de33ed" Value="c5fa114150"/>
+            <Line Type="bytes" Address="0x01de33f2" Value="e955000000"/>
+            <Line Type="bytes" Address="0x01de33f7" Value="498b542410"/>
+            <Line Type="bytes" Address="0x01de33fc" Value="c5fa104250"/>
+            <Line Type="bytes" Address="0x01de3401" Value="c5fa114150"/>
+            <Line Type="bytes" Address="0x01de3406" Value="c5fa104254"/>
+            <Line Type="bytes" Address="0x01de340b" Value="c5fa114154"/>
+            <Line Type="bytes" Address="0x01de3410" Value="c5fa104258"/>
+            <Line Type="bytes" Address="0x01de3415" Value="c5fa114158"/>
+            <Line Type="bytes" Address="0x01de341a" Value="c5fa10425c"/>
+            <Line Type="bytes" Address="0x01de341f" Value="c5fa11415c"/>
+            <Line Type="bytes" Address="0x01de3424" Value="c5f8284210"/>
+            <Line Type="bytes" Address="0x01de3429" Value="c5f8284a20"/>
+            <Line Type="bytes" Address="0x01de342e" Value="c5f8285230"/>
+            <Line Type="bytes" Address="0x01de3433" Value="c5f8285a40"/>
+            <Line Type="bytes" Address="0x01de3438" Value="c5f8294110"/>
+            <Line Type="bytes" Address="0x01de343d" Value="c5f8294920"/>
+            <Line Type="bytes" Address="0x01de3442" Value="c5f8295130"/>
+            <Line Type="bytes" Address="0x01de3447" Value="c5f8295940"/>
+            <Line Type="bytes" Address="0x01de344c" Value="4180bc24c400000001"/>
+            <Line Type="bytes" Address="0x01de3455" Value="7513"/>
+            <Line Type="bytes" Address="0x01de3457" Value="4180bc24c800000000"/>
+            <Line Type="bytes" Address="0x01de3460" Value="7508"/>
+            <Line Type="bytes" Address="0x01de3462" Value="41c6855001000001"/>
+            <Line Type="bytes" Address="0x01de346a" Value="58"/>
+            <Line Type="bytes" Address="0x01de346b" Value="be41000000"/>
+            <Line Type="bytes" Address="0x01de3470" Value="4889c7"/>
+            <Line Type="bytes" Address="0x01de3473" Value="e8e8e75aff"/>
+            <Line Type="bytes" Address="0x01de3478" Value="84c0"/>
+            <Line Type="bytes" Address="0x01de347a" Value="7408"/>
+            <Line Type="bytes" Address="0x01de347c" Value="41c6855001000000"/>
+            <Line Type="bytes" Address="0x01de3484" Value="4180bd5001000000"/>
+            <Line Type="bytes" Address="0x01de348c" Value="740a"/>
+            <Line Type="bytes" Address="0x01de348e" Value="41c6855101000001"/>
+            <Line Type="bytes" Address="0x01de3496" Value="eb08"/>
+            <Line Type="bytes" Address="0x01de3498" Value="41c6855101000000"/>
+            <Line Type="bytes" Address="0x01de34a0" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a1" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a2" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a3" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a4" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a5" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a6" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a7" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a8" Value="90"/>
+            <Line Type="bytes" Address="0x01de34a9" Value="90"/>
+            <Line Type="bytes" Address="0x01de34aa" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ab" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ac" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ad" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ae" Value="90"/>
+            <Line Type="bytes" Address="0x01de34af" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b0" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b1" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b2" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b3" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b4" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b5" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b6" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b7" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b8" Value="90"/>
+            <Line Type="bytes" Address="0x01de34b9" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ba" Value="90"/>
+            <Line Type="bytes" Address="0x01de34bb" Value="90"/>
+            <Line Type="bytes" Address="0x01de34bc" Value="90"/>
+            <Line Type="bytes" Address="0x01de34bd" Value="90"/>
+            <Line Type="bytes" Address="0x01de34be" Value="90"/>
+            <Line Type="bytes" Address="0x01de34bf" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c0" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c1" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c2" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c3" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c4" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c5" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c6" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c7" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c8" Value="90"/>
+            <Line Type="bytes" Address="0x01de34c9" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ca" Value="90"/>
+            <Line Type="bytes" Address="0x01de34cb" Value="90"/>
+            <Line Type="bytes" Address="0x01de34cc" Value="90"/>
+            <Line Type="bytes" Address="0x01de34cd" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ce" Value="90"/>
+            <Line Type="bytes" Address="0x01de34cf" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d0" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d1" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d2" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d3" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d4" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d5" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d6" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d7" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d8" Value="90"/>
+            <Line Type="bytes" Address="0x01de34d9" Value="90"/>
+            <Line Type="bytes" Address="0x01de34da" Value="90"/>
+            <Line Type="bytes" Address="0x01de34db" Value="90"/>
+            <Line Type="bytes" Address="0x01de34dc" Value="90"/>
+            <Line Type="bytes" Address="0x01de34dd" Value="90"/>
+            <Line Type="bytes" Address="0x01de34de" Value="90"/>
+            <Line Type="bytes" Address="0x01de34df" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e0" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e1" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e2" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e3" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e4" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e5" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e6" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e7" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e8" Value="90"/>
+            <Line Type="bytes" Address="0x01de34e9" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ea" Value="90"/>
+            <Line Type="bytes" Address="0x01de34eb" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ec" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ed" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ee" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ef" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f0" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f1" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f2" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f3" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f4" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f5" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f6" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f7" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f8" Value="90"/>
+            <Line Type="bytes" Address="0x01de34f9" Value="90"/>
+            <Line Type="bytes" Address="0x01de34fa" Value="90"/>
+            <Line Type="bytes" Address="0x01de34fb" Value="90"/>
+            <Line Type="bytes" Address="0x01de34fc" Value="90"/>
+            <Line Type="bytes" Address="0x01de34fd" Value="90"/>
+            <Line Type="bytes" Address="0x01de34fe" Value="90"/>
+            <Line Type="bytes" Address="0x01de34ff" Value="90"/>
+            <Line Type="bytes" Address="0x01de3500" Value="90"/>
+            <Line Type="bytes" Address="0x01de3501" Value="90"/>
+            <Line Type="bytes" Address="0x01de3502" Value="90"/>
+            <Line Type="bytes" Address="0x01de3503" Value="90"/>
+            <Line Type="bytes" Address="0x01de3504" Value="90"/>
+            <Line Type="bytes" Address="0x01de3505" Value="90"/>
+            <Line Type="bytes" Address="0x01de3506" Value="90"/>
+            <Line Type="bytes" Address="0x01de3507" Value="90"/>
+            <Line Type="bytes" Address="0x01de3508" Value="90"/>
+            <Line Type="bytes" Address="0x01de3509" Value="90"/>
+            <Line Type="bytes" Address="0x01de350a" Value="90"/>
+            <Line Type="bytes" Address="0x01de350b" Value="90"/>
+            <Line Type="bytes" Address="0x01de350c" Value="90"/>
+            <Line Type="bytes" Address="0x01de350d" Value="90"/>
+            <Line Type="bytes" Address="0x01de350e" Value="90"/>
+            <Line Type="bytes" Address="0x01de350f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3510" Value="90"/>
+            <Line Type="bytes" Address="0x01de3511" Value="90"/>
+            <Line Type="bytes" Address="0x01de3512" Value="90"/>
+            <Line Type="bytes" Address="0x01de3513" Value="90"/>
+            <Line Type="bytes" Address="0x01de3514" Value="90"/>
+            <Line Type="bytes" Address="0x01de3515" Value="90"/>
+            <Line Type="bytes" Address="0x01de3516" Value="90"/>
+            <Line Type="bytes" Address="0x01de3517" Value="90"/>
+            <Line Type="bytes" Address="0x01de3518" Value="90"/>
+            <Line Type="bytes" Address="0x01de3519" Value="90"/>
+            <Line Type="bytes" Address="0x01de351a" Value="90"/>
+            <Line Type="bytes" Address="0x01de351b" Value="90"/>
+            <Line Type="bytes" Address="0x01de351c" Value="90"/>
+            <Line Type="bytes" Address="0x01de351d" Value="90"/>
+            <Line Type="bytes" Address="0x01de351e" Value="90"/>
+            <Line Type="bytes" Address="0x01de351f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3520" Value="90"/>
+            <Line Type="bytes" Address="0x01de3521" Value="90"/>
+            <Line Type="bytes" Address="0x01de3522" Value="90"/>
+            <Line Type="bytes" Address="0x01de3523" Value="90"/>
+            <Line Type="bytes" Address="0x01de3524" Value="90"/>
+            <Line Type="bytes" Address="0x01de3525" Value="90"/>
+            <Line Type="bytes" Address="0x01de3526" Value="90"/>
+            <Line Type="bytes" Address="0x01de3527" Value="90"/>
+            <Line Type="bytes" Address="0x01de3528" Value="90"/>
+            <Line Type="bytes" Address="0x01de3529" Value="90"/>
+            <Line Type="bytes" Address="0x01de352a" Value="90"/>
+            <Line Type="bytes" Address="0x01de352b" Value="90"/>
+            <Line Type="bytes" Address="0x01de352c" Value="90"/>
+            <Line Type="bytes" Address="0x01de352d" Value="90"/>
+            <Line Type="bytes" Address="0x01de352e" Value="90"/>
+            <Line Type="bytes" Address="0x01de352f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3530" Value="90"/>
+            <Line Type="bytes" Address="0x01de3531" Value="90"/>
+            <Line Type="bytes" Address="0x01de3532" Value="90"/>
+            <Line Type="bytes" Address="0x01de3533" Value="90"/>
+            <Line Type="bytes" Address="0x01de3534" Value="90"/>
+            <Line Type="bytes" Address="0x01de3535" Value="90"/>
+            <Line Type="bytes" Address="0x01de3536" Value="90"/>
+            <Line Type="bytes" Address="0x01de3537" Value="90"/>
+            <Line Type="bytes" Address="0x01de3538" Value="90"/>
+            <Line Type="bytes" Address="0x01de3539" Value="90"/>
+            <Line Type="bytes" Address="0x01de353a" Value="90"/>
+            <Line Type="bytes" Address="0x01de353b" Value="90"/>
+            <Line Type="bytes" Address="0x01de353c" Value="90"/>
+            <Line Type="bytes" Address="0x01de353d" Value="90"/>
+            <Line Type="bytes" Address="0x01de353e" Value="90"/>
+            <Line Type="bytes" Address="0x01de353f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3540" Value="90"/>
+            <Line Type="bytes" Address="0x01de3541" Value="90"/>
+            <Line Type="bytes" Address="0x01de3542" Value="90"/>
+            <Line Type="bytes" Address="0x01de3543" Value="90"/>
+            <Line Type="bytes" Address="0x01de3544" Value="90"/>
+            <Line Type="bytes" Address="0x01de3545" Value="90"/>
+            <Line Type="bytes" Address="0x01de3546" Value="90"/>
+            <Line Type="bytes" Address="0x01de3547" Value="90"/>
+            <Line Type="bytes" Address="0x01de3548" Value="90"/>
+            <Line Type="bytes" Address="0x01de3549" Value="90"/>
+            <Line Type="bytes" Address="0x01de354a" Value="90"/>
+            <Line Type="bytes" Address="0x01de354b" Value="90"/>
+            <Line Type="bytes" Address="0x01de354c" Value="90"/>
+            <Line Type="bytes" Address="0x01de354d" Value="90"/>
+            <Line Type="bytes" Address="0x01de354e" Value="90"/>
+            <Line Type="bytes" Address="0x01de354f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3550" Value="90"/>
+            <Line Type="bytes" Address="0x01de3551" Value="90"/>
+            <Line Type="bytes" Address="0x01de3552" Value="90"/>
+            <Line Type="bytes" Address="0x01de3553" Value="90"/>
+            <Line Type="bytes" Address="0x01de3554" Value="90"/>
+            <Line Type="bytes" Address="0x01de3555" Value="90"/>
+            <Line Type="bytes" Address="0x01de3556" Value="90"/>
+            <Line Type="bytes" Address="0x01de3557" Value="90"/>
+            <Line Type="bytes" Address="0x01de3558" Value="90"/>
+            <Line Type="bytes" Address="0x01de3559" Value="90"/>
+            <Line Type="bytes" Address="0x01de355a" Value="90"/>
+            <Line Type="bytes" Address="0x01de355b" Value="90"/>
+            <Line Type="bytes" Address="0x01de355c" Value="90"/>
+            <Line Type="bytes" Address="0x01de355d" Value="90"/>
+            <Line Type="bytes" Address="0x01de355e" Value="90"/>
+            <Line Type="bytes" Address="0x01de355f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3560" Value="90"/>
+            <Line Type="bytes" Address="0x01de3561" Value="90"/>
+            <Line Type="bytes" Address="0x01de3562" Value="90"/>
+            <Line Type="bytes" Address="0x01de3563" Value="90"/>
+            <Line Type="bytes" Address="0x01de3564" Value="90"/>
+            <Line Type="bytes" Address="0x01de3565" Value="90"/>
+            <Line Type="bytes" Address="0x01de3566" Value="90"/>
+            <Line Type="bytes" Address="0x01de3567" Value="90"/>
+            <Line Type="bytes" Address="0x01de3568" Value="90"/>
+            <Line Type="bytes" Address="0x01de3569" Value="90"/>
+            <Line Type="bytes" Address="0x01de356a" Value="90"/>
+            <Line Type="bytes" Address="0x01de356b" Value="90"/>
+            <Line Type="bytes" Address="0x01de356c" Value="90"/>
+            <Line Type="bytes" Address="0x01de356d" Value="90"/>
+            <Line Type="bytes" Address="0x01de356e" Value="90"/>
+            <Line Type="bytes" Address="0x01de356f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3570" Value="90"/>
+            <Line Type="bytes" Address="0x01de3571" Value="90"/>
+            <Line Type="bytes" Address="0x01de3572" Value="90"/>
+            <Line Type="bytes" Address="0x01de3573" Value="90"/>
+            <Line Type="bytes" Address="0x01de3574" Value="90"/>
+            <Line Type="bytes" Address="0x01de3575" Value="90"/>
+            <Line Type="bytes" Address="0x01de3576" Value="90"/>
+            <Line Type="bytes" Address="0x01de3577" Value="90"/>
+            <Line Type="bytes" Address="0x01de3578" Value="90"/>
+            <Line Type="bytes" Address="0x01de3579" Value="90"/>
+            <Line Type="bytes" Address="0x01de357a" Value="90"/>
+            <Line Type="bytes" Address="0x01de357b" Value="90"/>
+            <Line Type="bytes" Address="0x01de357c" Value="90"/>
+            <Line Type="bytes" Address="0x01de357d" Value="90"/>
+            <Line Type="bytes" Address="0x01de357e" Value="90"/>
+            <Line Type="bytes" Address="0x01de357f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3580" Value="90"/>
+            <Line Type="bytes" Address="0x01de3581" Value="90"/>
+            <Line Type="bytes" Address="0x01de3582" Value="90"/>
+            <Line Type="bytes" Address="0x01de3583" Value="90"/>
+            <Line Type="bytes" Address="0x01de3584" Value="90"/>
+            <Line Type="bytes" Address="0x01de3585" Value="90"/>
+            <Line Type="bytes" Address="0x01de3586" Value="90"/>
+            <Line Type="bytes" Address="0x01de3587" Value="90"/>
+            <Line Type="bytes" Address="0x01de3588" Value="90"/>
+            <Line Type="bytes" Address="0x01de3589" Value="90"/>
+            <Line Type="bytes" Address="0x01de358a" Value="90"/>
+            <Line Type="bytes" Address="0x01de358b" Value="90"/>
+            <Line Type="bytes" Address="0x01de358c" Value="90"/>
+            <Line Type="bytes" Address="0x01de358d" Value="90"/>
+            <Line Type="bytes" Address="0x01de358e" Value="90"/>
+            <Line Type="bytes" Address="0x01de358f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3590" Value="90"/>
+            <Line Type="bytes" Address="0x01de3591" Value="90"/>
+            <Line Type="bytes" Address="0x01de3592" Value="90"/>
+            <Line Type="bytes" Address="0x01de3593" Value="90"/>
+            <Line Type="bytes" Address="0x01de3594" Value="90"/>
+            <Line Type="bytes" Address="0x01de3595" Value="90"/>
+            <Line Type="bytes" Address="0x01de3596" Value="90"/>
+            <Line Type="bytes" Address="0x01de3597" Value="90"/>
+            <Line Type="bytes" Address="0x01de3598" Value="90"/>
+            <Line Type="bytes" Address="0x01de3599" Value="90"/>
+            <Line Type="bytes" Address="0x01de359a" Value="90"/>
+            <Line Type="bytes" Address="0x01de359b" Value="90"/>
+            <Line Type="bytes" Address="0x01de359c" Value="90"/>
+            <Line Type="bytes" Address="0x01de359d" Value="90"/>
+            <Line Type="bytes" Address="0x01de359e" Value="90"/>
+            <Line Type="bytes" Address="0x01de359f" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a0" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a1" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a2" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a3" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a4" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a5" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a6" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a7" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a8" Value="90"/>
+            <Line Type="bytes" Address="0x01de35a9" Value="90"/>
+            <Line Type="bytes" Address="0x01de35aa" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ab" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ac" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ad" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ae" Value="90"/>
+            <Line Type="bytes" Address="0x01de35af" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b0" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b1" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b2" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b3" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b4" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b5" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b6" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b7" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b8" Value="90"/>
+            <Line Type="bytes" Address="0x01de35b9" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ba" Value="90"/>
+            <Line Type="bytes" Address="0x01de35bb" Value="90"/>
+            <Line Type="bytes" Address="0x01de35bc" Value="90"/>
+            <Line Type="bytes" Address="0x01de35bd" Value="90"/>
+            <Line Type="bytes" Address="0x01de35be" Value="90"/>
+            <Line Type="bytes" Address="0x01de35bf" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c0" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c1" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c2" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c3" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c4" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c5" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c6" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c7" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c8" Value="90"/>
+            <Line Type="bytes" Address="0x01de35c9" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ca" Value="90"/>
+            <Line Type="bytes" Address="0x01de35cb" Value="90"/>
+            <Line Type="bytes" Address="0x01de35cc" Value="90"/>
+            <Line Type="bytes" Address="0x01de35cd" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ce" Value="90"/>
+            <Line Type="bytes" Address="0x01de35cf" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d0" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d1" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d2" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d3" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d4" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d5" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d6" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d7" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d8" Value="90"/>
+            <Line Type="bytes" Address="0x01de35d9" Value="90"/>
+            <Line Type="bytes" Address="0x01de35da" Value="90"/>
+            <Line Type="bytes" Address="0x01de35db" Value="90"/>
+            <Line Type="bytes" Address="0x01de35dc" Value="90"/>
+            <Line Type="bytes" Address="0x01de35dd" Value="90"/>
+            <Line Type="bytes" Address="0x01de35de" Value="90"/>
+            <Line Type="bytes" Address="0x01de35df" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e0" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e1" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e2" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e3" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e4" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e5" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e6" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e7" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e8" Value="90"/>
+            <Line Type="bytes" Address="0x01de35e9" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ea" Value="90"/>
+            <Line Type="bytes" Address="0x01de35eb" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ec" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ed" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ee" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ef" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f0" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f1" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f2" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f3" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f4" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f5" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f6" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f7" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f8" Value="90"/>
+            <Line Type="bytes" Address="0x01de35f9" Value="90"/>
+            <Line Type="bytes" Address="0x01de35fa" Value="90"/>
+            <Line Type="bytes" Address="0x01de35fb" Value="90"/>
+            <Line Type="bytes" Address="0x01de35fc" Value="90"/>
+            <Line Type="bytes" Address="0x01de35fd" Value="90"/>
+            <Line Type="bytes" Address="0x01de35fe" Value="90"/>
+            <Line Type="bytes" Address="0x01de35ff" Value="90"/>
+            <Line Type="bytes" Address="0x01de3600" Value="90"/>
+            <Line Type="bytes" Address="0x01de3601" Value="90"/>
+            <Line Type="bytes" Address="0x01de3602" Value="90"/>
+            <Line Type="bytes" Address="0x01de3603" Value="90"/>
+            <Line Type="bytes" Address="0x01de3604" Value="90"/>
+            <Line Type="bytes" Address="0x01de3605" Value="90"/>
+            <Line Type="bytes" Address="0x01de3606" Value="90"/>
+            <Line Type="bytes" Address="0x01de3607" Value="90"/>
+            <Line Type="bytes" Address="0x01de3608" Value="90"/>
+            <Line Type="bytes" Address="0x01de3609" Value="90"/>
+            <Line Type="bytes" Address="0x01de360a" Value="90"/>
+            <Line Type="bytes" Address="0x01de360b" Value="90"/>
+            <Line Type="bytes" Address="0x01de360c" Value="90"/>
+            <Line Type="bytes" Address="0x01de360d" Value="90"/>
+            <Line Type="bytes" Address="0x01de360e" Value="90"/>
+            <Line Type="bytes" Address="0x01de360f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3610" Value="90"/>
+            <Line Type="bytes" Address="0x01de3611" Value="90"/>
+            <Line Type="bytes" Address="0x01de3612" Value="90"/>
+            <Line Type="bytes" Address="0x01de3613" Value="90"/>
+            <Line Type="bytes" Address="0x01de3614" Value="90"/>
+            <Line Type="bytes" Address="0x01de3615" Value="90"/>
+            <Line Type="bytes" Address="0x01de3616" Value="90"/>
+            <Line Type="bytes" Address="0x01de3617" Value="90"/>
+            <Line Type="bytes" Address="0x01de3618" Value="90"/>
+            <Line Type="bytes" Address="0x01de3619" Value="90"/>
+            <Line Type="bytes" Address="0x01de361a" Value="90"/>
+            <Line Type="bytes" Address="0x01de361b" Value="90"/>
+            <Line Type="bytes" Address="0x01de361c" Value="90"/>
+            <Line Type="bytes" Address="0x01de361d" Value="90"/>
+            <Line Type="bytes" Address="0x01de361e" Value="90"/>
+            <Line Type="bytes" Address="0x01de361f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3620" Value="90"/>
+            <Line Type="bytes" Address="0x01de3621" Value="90"/>
+            <Line Type="bytes" Address="0x01de3622" Value="90"/>
+            <Line Type="bytes" Address="0x01de3623" Value="90"/>
+            <Line Type="bytes" Address="0x01de3624" Value="90"/>
+            <Line Type="bytes" Address="0x01de3625" Value="90"/>
+            <Line Type="bytes" Address="0x01de3626" Value="90"/>
+            <Line Type="bytes" Address="0x01de3627" Value="90"/>
+            <Line Type="bytes" Address="0x01de3628" Value="90"/>
+            <Line Type="bytes" Address="0x01de3629" Value="90"/>
+            <Line Type="bytes" Address="0x01de362a" Value="90"/>
+            <Line Type="bytes" Address="0x01de362b" Value="90"/>
+            <Line Type="bytes" Address="0x01de362c" Value="90"/>
+            <Line Type="bytes" Address="0x01de362d" Value="90"/>
+            <Line Type="bytes" Address="0x01de362e" Value="90"/>
+            <Line Type="bytes" Address="0x01de362f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3630" Value="90"/>
+            <Line Type="bytes" Address="0x01de3631" Value="90"/>
+            <Line Type="bytes" Address="0x01de3632" Value="90"/>
+            <Line Type="bytes" Address="0x01de3633" Value="90"/>
+            <Line Type="bytes" Address="0x01de3634" Value="90"/>
+            <Line Type="bytes" Address="0x01de3635" Value="90"/>
+            <Line Type="bytes" Address="0x01de3636" Value="90"/>
+            <Line Type="bytes" Address="0x01de3637" Value="90"/>
+            <Line Type="bytes" Address="0x01de3638" Value="90"/>
+            <Line Type="bytes" Address="0x01de3639" Value="90"/>
+            <Line Type="bytes" Address="0x01de363a" Value="90"/>
+            <Line Type="bytes" Address="0x01de363b" Value="90"/>
+            <Line Type="bytes" Address="0x01de363c" Value="90"/>
+            <Line Type="bytes" Address="0x01de363d" Value="90"/>
+            <Line Type="bytes" Address="0x01de363e" Value="90"/>
+            <Line Type="bytes" Address="0x01de363f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3640" Value="90"/>
+            <Line Type="bytes" Address="0x01de3641" Value="90"/>
+            <Line Type="bytes" Address="0x01de3642" Value="90"/>
+            <Line Type="bytes" Address="0x01de3643" Value="90"/>
+            <Line Type="bytes" Address="0x01de3644" Value="90"/>
+            <Line Type="bytes" Address="0x01de3645" Value="90"/>
+            <Line Type="bytes" Address="0x01de3646" Value="90"/>
+            <Line Type="bytes" Address="0x01de3647" Value="90"/>
+            <Line Type="bytes" Address="0x01de3648" Value="90"/>
+            <Line Type="bytes" Address="0x01de3649" Value="90"/>
+            <Line Type="bytes" Address="0x01de364a" Value="90"/>
+            <Line Type="bytes" Address="0x01de364b" Value="90"/>
+            <Line Type="bytes" Address="0x01de364c" Value="90"/>
+            <Line Type="bytes" Address="0x01de364d" Value="90"/>
+            <Line Type="bytes" Address="0x01de364e" Value="90"/>
+            <Line Type="bytes" Address="0x01de364f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3650" Value="90"/>
+            <Line Type="bytes" Address="0x01de3651" Value="90"/>
+            <Line Type="bytes" Address="0x01de3652" Value="90"/>
+            <Line Type="bytes" Address="0x01de3653" Value="90"/>
+            <Line Type="bytes" Address="0x01de3654" Value="90"/>
+            <Line Type="bytes" Address="0x01de3655" Value="90"/>
+            <Line Type="bytes" Address="0x01de3656" Value="90"/>
+            <Line Type="bytes" Address="0x01de3657" Value="90"/>
+            <Line Type="bytes" Address="0x01de3658" Value="90"/>
+            <Line Type="bytes" Address="0x01de3659" Value="90"/>
+            <Line Type="bytes" Address="0x01de365a" Value="90"/>
+            <Line Type="bytes" Address="0x01de365b" Value="90"/>
+            <Line Type="bytes" Address="0x01de365c" Value="90"/>
+            <Line Type="bytes" Address="0x01de365d" Value="90"/>
+            <Line Type="bytes" Address="0x01de365e" Value="90"/>
+            <Line Type="bytes" Address="0x01de365f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3660" Value="90"/>
+            <Line Type="bytes" Address="0x01de3661" Value="90"/>
+            <Line Type="bytes" Address="0x01de3662" Value="90"/>
+            <Line Type="bytes" Address="0x01de3663" Value="90"/>
+            <Line Type="bytes" Address="0x01de3664" Value="90"/>
+            <Line Type="bytes" Address="0x01de3665" Value="90"/>
+            <Line Type="bytes" Address="0x01de3666" Value="90"/>
+            <Line Type="bytes" Address="0x01de3667" Value="90"/>
+            <Line Type="bytes" Address="0x01de3668" Value="90"/>
+            <Line Type="bytes" Address="0x01de3669" Value="90"/>
+            <Line Type="bytes" Address="0x01de366a" Value="90"/>
+            <Line Type="bytes" Address="0x01de366b" Value="90"/>
+            <Line Type="bytes" Address="0x01de366c" Value="90"/>
+            <Line Type="bytes" Address="0x01de366d" Value="90"/>
+            <Line Type="bytes" Address="0x01de366e" Value="90"/>
+            <Line Type="bytes" Address="0x01de366f" Value="90"/>
+            <Line Type="bytes" Address="0x01de3670" Value="90"/>
+            <Line Type="bytes" Address="0x01de3671" Value="90"/>
+            <Line Type="bytes" Address="0x01de3672" Value="90"/>
+            <Line Type="bytes" Address="0x01de3673" Value="90"/>
+            <Line Type="bytes" Address="0x01de3674" Value="90"/>
+            <Line Type="bytes" Address="0x01de3675" Value="90"/>
+            <Line Type="bytes" Address="0x01de3676" Value="90"/>
+            <Line Type="bytes" Address="0x01de3677" Value="90"/>
+            <Line Type="bytes" Address="0x01de3678" Value="90"/>
+            <Line Type="bytes" Address="0x01de3679" Value="90"/>
+            <Line Type="bytes" Address="0x01de367a" Value="90"/>
+            <Line Type="bytes" Address="0x01de367b" Value="90"/>
+            <Line Type="bytes" Address="0x01de367c" Value="90"/>
+            <Line Type="bytes" Address="0x01de367d" Value="4183bc24c400000001"/>
+            <Line Type="bytes" Address="0x01de3686" Value="e934f3b8ff"/>
+            <Line Type="bytes" Address="0x01de368b" Value="c3"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+             Name="Disable vsync" 
+             Author="illusion" 
+             PatchVer="1.0" 
+             AppVer="01.09" 
+             AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x025b3271" Value="4831f6"/>
+            <Line Type="bytes" Address="0x0243487e" Value="41c74424186f12833a"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+             Name="Draw Color Boarder (FLASHING COLORS WARNING)" 
+             Author="illusion" 
+             PatchVer="1.0" 
+             AppVer="01.09" 
+             AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01401136" Value="eb"/>
+            <Line Type="bytes" Address="0x01401168" Value="909090"/>
+            <Line Type="bytes" Address="0x01402a90" Value="c3"/>
+            <Line Type="bytes" Address="0x0140be00" Value="e98c6cffff"/>
+            <Line Type="bytes" Address="0x01402a91" Value="50"/>
+            <Line Type="bytes" Address="0x01402a92" Value="56"/>
+            <Line Type="bytes" Address="0x01402a93" Value="48c7472800000000"/>
+            <Line Type="bytes" Address="0x01402a9b" Value="c7473000000042"/>
+            <Line Type="bytes" Address="0x01402aa2" Value="488d354f5f1204"/>
+            <Line Type="bytes" Address="0x01402aa9" Value="8b4604"/>
+            <Line Type="bytes" Address="0x01402aac" Value="c5fa2ac0"/>
+            <Line Type="bytes" Address="0x01402ab0" Value="c5fa114734"/>
+            <Line Type="bytes" Address="0x01402ab5" Value="488d0584950d04"/>
+            <Line Type="bytes" Address="0x01402abc" Value="c747500000803f"/>
+            <Line Type="bytes" Address="0x01402ac3" Value="c747540000803f"/>
+            <Line Type="bytes" Address="0x01402aca" Value="c747580000803f"/>
+            <Line Type="bytes" Address="0x01402ad1" Value="c7475c0000803f"/>
+            <Line Type="bytes" Address="0x01402ad8" Value="83380f"/>
+            <Line Type="bytes" Address="0x01402adb" Value="0f8790000000"/>
+            <Line Type="bytes" Address="0x01402ae1" Value="833800"/>
+            <Line Type="bytes" Address="0x01402ae4" Value="0f8492000000"/>
+            <Line Type="bytes" Address="0x01402aea" Value="833801"/>
+            <Line Type="bytes" Address="0x01402aed" Value="0f84a3000000"/>
+            <Line Type="bytes" Address="0x01402af3" Value="833802"/>
+            <Line Type="bytes" Address="0x01402af6" Value="0f84b4000000"/>
+            <Line Type="bytes" Address="0x01402afc" Value="833803"/>
+            <Line Type="bytes" Address="0x01402aff" Value="0f84c5000000"/>
+            <Line Type="bytes" Address="0x01402b05" Value="833804"/>
+            <Line Type="bytes" Address="0x01402b08" Value="0f84d6000000"/>
+            <Line Type="bytes" Address="0x01402b0e" Value="833805"/>
+            <Line Type="bytes" Address="0x01402b11" Value="0f84e7000000"/>
+            <Line Type="bytes" Address="0x01402b17" Value="833806"/>
+            <Line Type="bytes" Address="0x01402b1a" Value="0f84f8000000"/>
+            <Line Type="bytes" Address="0x01402b20" Value="833807"/>
+            <Line Type="bytes" Address="0x01402b23" Value="0f8409010000"/>
+            <Line Type="bytes" Address="0x01402b29" Value="833808"/>
+            <Line Type="bytes" Address="0x01402b2c" Value="0f841a010000"/>
+            <Line Type="bytes" Address="0x01402b32" Value="833809"/>
+            <Line Type="bytes" Address="0x01402b35" Value="0f842b010000"/>
+            <Line Type="bytes" Address="0x01402b3b" Value="83380a"/>
+            <Line Type="bytes" Address="0x01402b3e" Value="0f843c010000"/>
+            <Line Type="bytes" Address="0x01402b44" Value="83380b"/>
+            <Line Type="bytes" Address="0x01402b47" Value="0f844a010000"/>
+            <Line Type="bytes" Address="0x01402b4d" Value="83380c"/>
+            <Line Type="bytes" Address="0x01402b50" Value="0f8458010000"/>
+            <Line Type="bytes" Address="0x01402b56" Value="83380d"/>
+            <Line Type="bytes" Address="0x01402b59" Value="0f8466010000"/>
+            <Line Type="bytes" Address="0x01402b5f" Value="83380e"/>
+            <Line Type="bytes" Address="0x01402b62" Value="0f8474010000"/>
+            <Line Type="bytes" Address="0x01402b68" Value="83380f"/>
+            <Line Type="bytes" Address="0x01402b6b" Value="0f8482010000"/>
+            <Line Type="bytes" Address="0x01402b71" Value="c70001000000"/>
+            <Line Type="bytes" Address="0x01402b77" Value="e98f010000"/>
+            <Line Type="bytes" Address="0x01402b7c" Value="c747500000803f"/>
+            <Line Type="bytes" Address="0x01402b83" Value="c747540000803f"/>
+            <Line Type="bytes" Address="0x01402b8a" Value="c747580000803f"/>
+            <Line Type="bytes" Address="0x01402b91" Value="e972010000"/>
+            <Line Type="bytes" Address="0x01402b96" Value="c7475000000000"/>
+            <Line Type="bytes" Address="0x01402b9d" Value="c747540000803f"/>
+            <Line Type="bytes" Address="0x01402ba4" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402bab" Value="e958010000"/>
+            <Line Type="bytes" Address="0x01402bb0" Value="c7475000000000"/>
+            <Line Type="bytes" Address="0x01402bb7" Value="c7475400000000"/>
+            <Line Type="bytes" Address="0x01402bbe" Value="c747580000803f"/>
+            <Line Type="bytes" Address="0x01402bc5" Value="e93e010000"/>
+            <Line Type="bytes" Address="0x01402bca" Value="c747500000803f"/>
+            <Line Type="bytes" Address="0x01402bd1" Value="c7475400000000"/>
+            <Line Type="bytes" Address="0x01402bd8" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402bdf" Value="e924010000"/>
+            <Line Type="bytes" Address="0x01402be4" Value="c7475000000000"/>
+            <Line Type="bytes" Address="0x01402beb" Value="c747540000003f"/>
+            <Line Type="bytes" Address="0x01402bf2" Value="c747580000003f"/>
+            <Line Type="bytes" Address="0x01402bf9" Value="e90a010000"/>
+            <Line Type="bytes" Address="0x01402bfe" Value="c7475000000000"/>
+            <Line Type="bytes" Address="0x01402c05" Value="c7475400000000"/>
+            <Line Type="bytes" Address="0x01402c0c" Value="c747580000003f"/>
+            <Line Type="bytes" Address="0x01402c13" Value="e9f0000000"/>
+            <Line Type="bytes" Address="0x01402c18" Value="c7475000000000"/>
+            <Line Type="bytes" Address="0x01402c1f" Value="c747540000003f"/>
+            <Line Type="bytes" Address="0x01402c26" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402c2d" Value="e9d6000000"/>
+            <Line Type="bytes" Address="0x01402c32" Value="c7475000000000"/>
+            <Line Type="bytes" Address="0x01402c39" Value="c747540000803f"/>
+            <Line Type="bytes" Address="0x01402c40" Value="c747580000803f"/>
+            <Line Type="bytes" Address="0x01402c47" Value="e9bc000000"/>
+            <Line Type="bytes" Address="0x01402c4c" Value="c747500000003f"/>
+            <Line Type="bytes" Address="0x01402c53" Value="c7475400000000"/>
+            <Line Type="bytes" Address="0x01402c5a" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402c61" Value="e9a2000000"/>
+            <Line Type="bytes" Address="0x01402c66" Value="c747500000403f"/>
+            <Line Type="bytes" Address="0x01402c6d" Value="c747540000403f"/>
+            <Line Type="bytes" Address="0x01402c74" Value="c747580000403f"/>
+            <Line Type="bytes" Address="0x01402c7b" Value="e988000000"/>
+            <Line Type="bytes" Address="0x01402c80" Value="c747500000003f"/>
+            <Line Type="bytes" Address="0x01402c87" Value="c7475400000000"/>
+            <Line Type="bytes" Address="0x01402c8e" Value="c747580000003f"/>
+            <Line Type="bytes" Address="0x01402c95" Value="eb71"/>
+            <Line Type="bytes" Address="0x01402c97" Value="c747500000003f"/>
+            <Line Type="bytes" Address="0x01402c9e" Value="c747540000003f"/>
+            <Line Type="bytes" Address="0x01402ca5" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402cac" Value="eb5a"/>
+            <Line Type="bytes" Address="0x01402cae" Value="c747500000003f"/>
+            <Line Type="bytes" Address="0x01402cb5" Value="c747540000003f"/>
+            <Line Type="bytes" Address="0x01402cbc" Value="c747580000003f"/>
+            <Line Type="bytes" Address="0x01402cc3" Value="eb43"/>
+            <Line Type="bytes" Address="0x01402cc5" Value="c747500000803f"/>
+            <Line Type="bytes" Address="0x01402ccc" Value="c7475400000000"/>
+            <Line Type="bytes" Address="0x01402cd3" Value="c747580000803f"/>
+            <Line Type="bytes" Address="0x01402cda" Value="eb2c"/>
+            <Line Type="bytes" Address="0x01402cdc" Value="c747500000803f"/>
+            <Line Type="bytes" Address="0x01402ce3" Value="c747540000803f"/>
+            <Line Type="bytes" Address="0x01402cea" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402cf1" Value="eb15"/>
+            <Line Type="bytes" Address="0x01402cf3" Value="c747500000803f"/>
+            <Line Type="bytes" Address="0x01402cfa" Value="c747540000003f"/>
+            <Line Type="bytes" Address="0x01402d01" Value="c7475800000000"/>
+            <Line Type="bytes" Address="0x01402d08" Value="830001"/>
+            <Line Type="bytes" Address="0x01402d0b" Value="5e"/>
+            <Line Type="bytes" Address="0x01402d0c" Value="58"/>
+            <Line Type="bytes" Address="0x01402d0d" Value="c5f8284750"/>
+            <Line Type="bytes" Address="0x01402d12" Value="e9ee900000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+             Name="Restore Debug Dash" 
+             Note="Press L3 to activate/deactivate then hold L2 to increase or L1 to decrease your current altitude and R2 for noclip." Author="stagvant" 
+             PatchVer="1.0" 
+             AppVer="01.09" 
+             AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01cbd711" Value="e9cee10703"/>
+            <Line Type="bytes" Address="0x04d3b8e4" Value="c5fa114584"/>
+            <Line Type="bytes" Address="0x04d3b8e9" Value="488b0d902fc000"/>
+            <Line Type="bytes" Address="0x04d3b8f0" Value="488b3df978b700"/>
+            <Line Type="bytes" Address="0x04d3b8f7" Value="488b357a2fc000"/>
+            <Line Type="bytes" Address="0x04d3b8fe" Value="488b8108010000"/>
+            <Line Type="bytes" Address="0x04d3b905" Value="4885c0"/>
+            <Line Type="bytes" Address="0x04d3b908" Value="7504"/>
+            <Line Type="bytes" Address="0x04d3b90a" Value="488b4660"/>
+            <Line Type="bytes" Address="0x04d3b90e" Value="4939c5"/>
+            <Line Type="bytes" Address="0x04d3b911" Value="0f85ff1df8fc"/>
+            <Line Type="bytes" Address="0x04d3b917" Value="4c8bf9"/>
+            <Line Type="bytes" Address="0x04d3b91a" Value="488d0d87abc000"/>
+            <Line Type="bytes" Address="0x04d3b921" Value="488b4738"/>
+            <Line Type="bytes" Address="0x04d3b925" Value="488b4008"/>
+            <Line Type="bytes" Address="0x04d3b929" Value="488d5808"/>
+            <Line Type="bytes" Address="0x04d3b92d" Value="488bd0"/>
+            <Line Type="bytes" Address="0x04d3b930" Value="eb06"/>
+            <Line Type="bytes" Address="0x04d3b932" Value="488bde"/>
+            <Line Type="bytes" Address="0x04d3b935" Value="488bd6"/>
+            <Line Type="bytes" Address="0x04d3b938" Value="488b33"/>
+            <Line Type="bytes" Address="0x04d3b93b" Value="807e1900"/>
+            <Line Type="bytes" Address="0x04d3b93f" Value="750c"/>
+            <Line Type="bytes" Address="0x04d3b941" Value="488d5e10"/>
+            <Line Type="bytes" Address="0x04d3b945" Value="48394e20"/>
+            <Line Type="bytes" Address="0x04d3b949" Value="7ced"/>
+            <Line Type="bytes" Address="0x04d3b94b" Value="ebe5"/>
+            <Line Type="bytes" Address="0x04d3b94d" Value="4839c2"/>
+            <Line Type="bytes" Address="0x04d3b950" Value="741b"/>
+            <Line Type="bytes" Address="0x04d3b952" Value="48394a20"/>
+            <Line Type="bytes" Address="0x04d3b956" Value="488bc8"/>
+            <Line Type="bytes" Address="0x04d3b959" Value="7f03"/>
+            <Line Type="bytes" Address="0x04d3b95b" Value="488bca"/>
+            <Line Type="bytes" Address="0x04d3b95e" Value="4839c1"/>
+            <Line Type="bytes" Address="0x04d3b961" Value="740a"/>
+            <Line Type="bytes" Address="0x04d3b963" Value="c6413001"/>
+            <Line Type="bytes" Address="0x04d3b967" Value="4c8b7128"/>
+            <Line Type="bytes" Address="0x04d3b96b" Value="eb0b"/>
+            <Line Type="bytes" Address="0x04d3b96d" Value="4831f6"/>
+            <Line Type="bytes" Address="0x04d3b970" Value="e83bab9cfc"/>
+            <Line Type="bytes" Address="0x04d3b975" Value="4c8bf0"/>
+            <Line Type="bytes" Address="0x04d3b978" Value="be17000000"/>
+            <Line Type="bytes" Address="0x04d3b97d" Value="498bfe"/>
+            <Line Type="bytes" Address="0x04d3b980" Value="e8db6265fc"/>
+            <Line Type="bytes" Address="0x04d3b985" Value="84c0"/>
+            <Line Type="bytes" Address="0x04d3b987" Value="7405"/>
+            <Line Type="bytes" Address="0x04d3b989" Value="4180773101"/>
+            <Line Type="bytes" Address="0x04d3b98e" Value="41807f3100"/>
+            <Line Type="bytes" Address="0x04d3b993" Value="0f8487000000"/>
+            <Line Type="bytes" Address="0x04d3b999" Value="41808de101000040"/>
+            <Line Type="bytes" Address="0x04d3b9a1" Value="0f280da8c6dfff"/>
+            <Line Type="bytes" Address="0x04d3b9a8" Value="0f590d817bf9ff"/>
+            <Line Type="bytes" Address="0x04d3b9af" Value="488d7dc0"/>
+            <Line Type="bytes" Address="0x04d3b9b3" Value="498bc5"/>
+            <Line Type="bytes" Address="0x04d3b9b6" Value="e861c09cfc"/>
+            <Line Type="bytes" Address="0x04d3b9bb" Value="be18000000"/>
+            <Line Type="bytes" Address="0x04d3b9c0" Value="498bfe"/>
+            <Line Type="bytes" Address="0x04d3b9c3" Value="e8986265fc"/>
+            <Line Type="bytes" Address="0x04d3b9c8" Value="84c0"/>
+            <Line Type="bytes" Address="0x04d3b9ca" Value="7403"/>
+            <Line Type="bytes" Address="0x04d3b9cc" Value="0f58c1"/>
+            <Line Type="bytes" Address="0x04d3b9cf" Value="be19000000"/>
+            <Line Type="bytes" Address="0x04d3b9d4" Value="498bfe"/>
+            <Line Type="bytes" Address="0x04d3b9d7" Value="e8846265fc"/>
+            <Line Type="bytes" Address="0x04d3b9dc" Value="84c0"/>
+            <Line Type="bytes" Address="0x04d3b9de" Value="7403"/>
+            <Line Type="bytes" Address="0x04d3b9e0" Value="0f5cc1"/>
+            <Line Type="bytes" Address="0x04d3b9e3" Value="488d75c0"/>
+            <Line Type="bytes" Address="0x04d3b9e7" Value="0f2906"/>
+            <Line Type="bytes" Address="0x04d3b9ea" Value="498bfd"/>
+            <Line Type="bytes" Address="0x04d3b9ed" Value="e8ae5cf8fc"/>
+            <Line Type="bytes" Address="0x04d3b9f2" Value="be1a000000"/>
+            <Line Type="bytes" Address="0x04d3b9f7" Value="498bfe"/>
+            <Line Type="bytes" Address="0x04d3b9fa" Value="e8616265fc"/>
+            <Line Type="bytes" Address="0x04d3b9ff" Value="498b4d58"/>
+            <Line Type="bytes" Address="0x04d3ba03" Value="84c0"/>
+            <Line Type="bytes" Address="0x04d3ba05" Value="740c"/>
+            <Line Type="bytes" Address="0x04d3ba07" Value="6683891401000008"/>
+            <Line Type="bytes" Address="0x04d3ba0f" Value="b001"/>
+            <Line Type="bytes" Address="0x04d3ba11" Value="eb17"/>
+            <Line Type="bytes" Address="0x04d3ba13" Value="66c781140100000000"/>
+            <Line Type="bytes" Address="0x04d3ba1c" Value="b001"/>
+            <Line Type="bytes" Address="0x04d3ba1e" Value="eb0a"/>
+            <Line Type="bytes" Address="0x04d3ba20" Value="4180a5e1010000bf"/>
+            <Line Type="bytes" Address="0x04d3ba28" Value="30c0"/>
+            <Line Type="bytes" Address="0x04d3ba2a" Value="c5fa104584"/>
+            <Line Type="bytes" Address="0x04d3ba2f" Value="84c0"/>
+            <Line Type="bytes" Address="0x04d3ba31" Value="0f84df1cf8fc"/>
+            <Line Type="bytes" Address="0x04d3ba37" Value="f30f59059d98feff"/>
+            <Line Type="bytes" Address="0x04d3ba3f" Value="e9d21cf8fc"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Unlock Game Region" 
+              Note="Unlocks the game region to support additional language options, switches the X and Circle buttons" 
+              Author="Lance McDonald (manfightdragon)" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x023b9190" Value="b805000000c3"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Bookmark and Capture outputs" 
+              Author="Foxy Hooligans" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x04dba9be" Value="2f0064006100740061002f0062006c006f006f00640062006f0072006e0065002f000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+             Name="Enemy Control" Note="R3 to control targeted enemy / L3 to go back" 
+             Author="stagvant" 
+             PatchVer="1.0" 
+             AppVer="01.09" 
+             AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x1c90e60" Value="0f85ac00"/>
+            <Line Type="bytes" Address="0x1c90e64" Value="00004c8d"/>
+            <Line Type="bytes" Address="0x1c90e68" Value="2d0bdaca"/>
+            <Line Type="bytes" Address="0x1c90e6c" Value="03498b4d"/>
+            <Line Type="bytes" Address="0x1c90e70" Value="004885c9"/>
+            <Line Type="bytes" Address="0x1c90e74" Value="75318d3d"/>
+            <Line Type="bytes" Address="0x1c90e78" Value="eda40a03"/>
+            <Line Type="bytes" Address="0x1c90e7c" Value="8d153ba5"/>
+            <Line Type="bytes" Address="0x1c90e80" Value="0a038d0d"/>
+            <Line Type="bytes" Address="0x1c90e84" Value="e3a30a03"/>
+            <Line Type="bytes" Address="0x1c90e88" Value="beb10000"/>
+            <Line Type="bytes" Address="0x1c90e8c" Value="0031c04d"/>
+            <Line Type="bytes" Address="0x1c90e90" Value="8be64d8b"/>
+            <Line Type="bytes" Address="0x1c90e94" Value="f0e81647"/>
+            <Line Type="bytes" Address="0x1c90e98" Value="82004d8b"/>
+            <Line Type="bytes" Address="0x1c90e9c" Value="c64d8bf4"/>
+            <Line Type="bytes" Address="0x1c90ea0" Value="498b4d00"/>
+            <Line Type="bytes" Address="0x1c90ea4" Value="8b436483"/>
+            <Line Type="bytes" Address="0x1c90ea8" Value="f8ff7466"/>
+            <Line Type="bytes" Address="0x1c90eac" Value="ba0e0600"/>
+            <Line Type="bytes" Address="0x1c90eb0" Value="00c4e268"/>
+            <Line Type="bytes" Address="0x1c90eb4" Value="f7d0488b"/>
+            <Line Type="bytes" Address="0x1c90eb8" Value="71088b76"/>
+            <Line Type="bytes" Address="0x1c90ebc" Value="1883c602"/>
+            <Line Type="bytes" Address="0x1c90ec0" Value="39f27d4e"/>
+            <Line Type="bytes" Address="0x1c90ec4" Value="8bd2488b"/>
+            <Line Type="bytes" Address="0x1c90ec8" Value="8cd15008"/>
+            <Line Type="bytes" Address="0x1c90ecc" Value="00004885"/>
+            <Line Type="bytes" Address="0x1c90ed0" Value="c9743f25"/>
+            <Line Type="bytes" Address="0x1c90ed4" Value="ff3f0000"/>
+            <Line Type="bytes" Address="0x1c90ed8" Value="3b017d36"/>
+            <Line Type="bytes" Address="0x1c90edc" Value="486bc038"/>
+            <Line Type="bytes" Address="0x1c90ee0" Value="48034108"/>
+            <Line Type="bytes" Address="0x1c90ee4" Value="742c488b"/>
+            <Line Type="bytes" Address="0x1c90ee8" Value="004885c0"/>
+            <Line Type="bytes" Address="0x1c90eec" Value="74244150"/>
+            <Line Type="bytes" Address="0x1c90ef0" Value="56575031"/>
+            <Line Type="bytes" Address="0x1c90ef4" Value="f6488bf8"/>
+            <Line Type="bytes" Address="0x1c90ef8" Value="c6808800"/>
+            <Line Type="bytes" Address="0x1c90efc" Value="00001de8"/>
+            <Line Type="bytes" Address="0x1c90f00" Value="0ccf0300"/>
+            <Line Type="bytes" Address="0x1c90f04" Value="585f5e41"/>
+            <Line Type="bytes" Address="0x1c90f08" Value="58837878"/>
+            <Line Type="bytes" Address="0x1c90f0c" Value="070f94c0"/>
+            <Line Type="bytes" Address="0x197296a" Value="064889f3"/>
+            <Line Type="bytes" Address="0x197296e" Value="4889f248"/>
+            <Line Type="bytes" Address="0x1972972" Value="8b33807e"/>
+            <Line Type="bytes" Address="0x1972976" Value="1900750c"/>
+            <Line Type="bytes" Address="0x197297a" Value="488d5e10"/>
+            <Line Type="bytes" Address="0x197297e" Value="48394e20"/>
+            <Line Type="bytes" Address="0x1972982" Value="7cedebe5"/>
+            <Line Type="bytes" Address="0x1972986" Value="4839c274"/>
+            <Line Type="bytes" Address="0x197298a" Value="1b48394a"/>
+            <Line Type="bytes" Address="0x197298e" Value="20488bc8"/>
+            <Line Type="bytes" Address="0x1972992" Value="7f03488b"/>
+            <Line Type="bytes" Address="0x1972996" Value="ca4839c1"/>
+            <Line Type="bytes" Address="0x197299a" Value="740ac641"/>
+            <Line Type="bytes" Address="0x197299e" Value="3001488b"/>
+            <Line Type="bytes" Address="0x19729a2" Value="4128eb08"/>
+            <Line Type="bytes" Address="0x19729a6" Value="4831f6e8"/>
+            <Line Type="bytes" Address="0x19729aa" Value="023bd9ff"/>
+            <Line Type="bytes" Address="0x19729ae" Value="48c7c617"/>
+            <Line Type="bytes" Address="0x19729b2" Value="00000048"/>
+            <Line Type="bytes" Address="0x19729b6" Value="8bf8e8a3"/>
+            <Line Type="bytes" Address="0x19729ba" Value="f2a1ff84"/>
+            <Line Type="bytes" Address="0x19729be" Value="c0741741"/>
+            <Line Type="bytes" Address="0x19729c2" Value="50565750"/>
+            <Line Type="bytes" Address="0x19729c6" Value="4831ffbe"/>
+            <Line Type="bytes" Address="0x19729ca" Value="28000000"/>
+            <Line Type="bytes" Address="0x19729ce" Value="e83db435"/>
+            <Line Type="bytes" Address="0x19729d2" Value="00585f5e"/>
+            <Line Type="bytes" Address="0x19729d6" Value="41584183"/>
+            <Line Type="bytes" Address="0x19729da" Value="bc24c400"/>
+            <Line Type="bytes" Address="0x19729de" Value="0000010f"/>
+            <Line Type="bytes" Address="0x19729e2" Value="85be0000"/>
+            <Line Type="bytes" Address="0x19729e6" Value="004183bc"/>
+            <Line Type="bytes" Address="0x19729ea" Value="24c80000"/>
+            <Line Type="bytes" Address="0x19729ee" Value="00000f85"/>
+            <Line Type="bytes" Address="0x19729f2" Value="af000000"/>
+            <Line Type="bytes" Address="0x19729f6" Value="498b3f48"/>
+            <Line Type="bytes" Address="0x19729fa" Value="85ff7524"/>
+            <Line Type="bytes" Address="0x19729fe" Value="488d3d64"/>
+            <Line Type="bytes" Address="0x1972a02" Value="893c0348"/>
+            <Line Type="bytes" Address="0x1972a06" Value="8d15b189"/>
+            <Line Type="bytes" Address="0x1972a0a" Value="3c03488d"/>
+            <Line Type="bytes" Address="0x1972a0e" Value="0d27893c"/>
+            <Line Type="bytes" Address="0x1972a12" Value="03beb100"/>
+            <Line Type="bytes" Address="0x1972a16" Value="000031c0"/>
+            <Line Type="bytes" Address="0x1972a1a" Value="e8912bb4"/>
+            <Line Type="bytes" Address="0x1972a1e" Value="00498b3f"/>
+            <Line Type="bytes" Address="0x1972a22" Value="488b4738"/>
+            <Line Type="bytes" Address="0x1972a26" Value="488b4008"/>
+            <Line Type="bytes" Address="0x1972a2a" Value="488d5808"/>
+            <Line Type="bytes" Address="0x1972a2e" Value="488d0d8f"/>
+            <Line Type="bytes" Address="0x1972a32" Value="3cfe0348"/>
+            <Line Type="bytes" Address="0x1972a36" Value="8bd0eb06"/>
+            <Line Type="bytes" Address="0x1972a3a" Value="488bde48"/>
+            <Line Type="bytes" Address="0x1972a3e" Value="8bd6488b"/>
+            <Line Type="bytes" Address="0x1972a42" Value="33807e19"/>
+            <Line Type="bytes" Address="0x1972a46" Value="00750c48"/>
+            <Line Type="bytes" Address="0x1972a4a" Value="8d5e1048"/>
+            <Line Type="bytes" Address="0x1972a4e" Value="394e207c"/>
+            <Line Type="bytes" Address="0x1972a52" Value="edebe548"/>
+            <Line Type="bytes" Address="0x1972a56" Value="39c2741b"/>
+            <Line Type="bytes" Address="0x1972a5a" Value="48394a20"/>
+            <Line Type="bytes" Address="0x1972a5e" Value="488bc87f"/>
+            <Line Type="bytes" Address="0x1972a62" Value="03488bca"/>
+            <Line Type="bytes" Address="0x1972a66" Value="4839c174"/>
+            <Line Type="bytes" Address="0x1972a6a" Value="0ac64130"/>
+            <Line Type="bytes" Address="0x1972a6e" Value="01488b41"/>
+            <Line Type="bytes" Address="0x1972a72" Value="28eb05e8"/>
+            <Line Type="bytes" Address="0x1972a76" Value="56020000"/>
+            <Line Type="bytes" Address="0x1972a7a" Value="488945c0"/>
+            <Line Type="bytes" Address="0x1972a7e" Value="488d05ab"/>
+            <Line Type="bytes" Address="0x1972a82" Value="d2d70348"/>
+            <Line Type="bytes" Address="0x1972a86" Value="83c01048"/>
+            <Line Type="bytes" Address="0x1972a8a" Value="8945c8c7"/>
+            <Line Type="bytes" Address="0x1972a8e" Value="45d08988"/>
+            <Line Type="bytes" Address="0x1972a92" Value="083d498b"/>
+            <Line Type="bytes" Address="0x1972a96" Value="bc24d000"/>
+            <Line Type="bytes" Address="0x1972a9a" Value="0000488d"/>
+            <Line Type="bytes" Address="0x1972a9e" Value="75c0e80b"/>
+            <Line Type="bytes" Address="0x1972aa2" Value="1b7a0049"/>
+            <Line Type="bytes" Address="0x1972aa6" Value="8b06483b"/>
+            <Line Type="bytes" Address="0x1972aaa" Value="45d8750d"/>
+            <Line Type="bytes" Address="0x1972aae" Value="4883c420"/>
+            <Line Type="bytes" Address="0x1972ab2" Value="5b415c41"/>
+            <Line Type="bytes" Address="0x1972ab6" Value="5e415f5d"/>
+            <Line Type="bytes" Address="0x1972aba" Value="c3e838ba"/>
+            <Line Type="bytes" Address="0x1972abe" Value="6401"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+             Name="Resolution Patch (360p)" 
+             Note="Recommended for weaker GPUs. Enemy HP bars are often invisible when in the center of the screen." 
+             Author="LeDragoX" 
+             PatchVer="1.0" 
+             AppVer="01.09" 
+             AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000280"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000168"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+             Name="Resolution Patch (484p)" 
+             Note="Recommended for weaker GPUs. Enemy HP bars are often invisible when in the center of the screen." 
+             Author="LeDragoX, xzy" 
+             PatchVer="1.0" 
+             AppVer="01.09" 
+             AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x0000035c"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000001e4"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (720p)" 
+              Author="Lance McDonald (manfightdragon)" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000500"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000002d0"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (900p)" 
+              Author="LeDragoX" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000640"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000384"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2560x1440)" 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000A00"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000005A0"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (3200x1800)" 
+              Note="High VRAM requirements." 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000C80"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000708"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (3840x2160)" 
+              Note="Crashes unless 4090." 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000F00"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000870"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (1280x800) (16:10)" 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000500"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000320"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="cdcccc3f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2560x1080) (21:9 2.37)" 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000A00"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000438"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="26b41740"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (3440x1440) (21:9 2.38)" 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000D70"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000005A0"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="8ee31840"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (3840x1080) (32:9 ~3.55)" 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000F00"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000438"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398e6340"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (1280x960) (4:3 ~1.33)" 
+              Author="xzy" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000500"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000003C0"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="abaaaa3f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2304x1296)" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000900"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000510"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2300x1294)" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008FC"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x0000050E"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8FC080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b80E050000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8FC080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b80E050000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2248x1265)" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008C8"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000004F1"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8C8080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b8F1040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8C8080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b8F1040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2290x1420)" 
+              Note="Highest possible without no issues/Health Bars are Moved" 
+              Author="Dmugetsu" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008F2"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x0000058C"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8F2080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b88C050000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8F2080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b88C050000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2290x1400)" 
+              Note="Highest possible without no issues/Health Bars are Moved" 
+              Author="Dmugetsu" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008F2"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000580"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8F2080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b880040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8F2080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b880040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2359x1271)" 
+              Note="HighResolution NO crash/Health Bars are Moved" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000937"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000004F7"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8D3090000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b8F7040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8D3090000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b8F7040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2300x1400)" 
+              Note="Highest possible without no issues/Health Bars are Moved" 
+              Author="Dmugetsu" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008FC"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000580"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8FC080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b880040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8FC080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b880040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2352x661)" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000930"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000295"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b830090000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b895020000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b830090000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b895020000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2359x1300)" 
+              Note="HighResolution NO crash/Health Bars are Moved" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000937"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000514"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8D3090000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b8F4050000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8D3090000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b8F4050000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2259x1271)" 
+              Note="HighResolution NO crash/Health Bars are Moved" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008D3"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000004F7"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b8D3080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b8F7040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b8D3080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b8F7040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2176x1224)" 
+              Note="HighResolution NO crash/Health Bars are Moved" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000880"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x000004C8"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880080000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b8C8040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880080000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b8C8040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (3200x1800)" 
+              Author="Dlix" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000C80"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000708"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2048x1152)" 
+              Author="you!" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x00000800"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x00000480"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+            <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Resolution Patch (2280x1283)" 
+              Author="LeDragoX" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x055289f8" Value="0x000008F8"/>
+            <Line Type="bytes32" Address="0x055289fc" Value="0x0000050B"/>
+            <Line Type="bytes" Address="0x01a44c55" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a44c5a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5b" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5c" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5d" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c5e" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a44c63" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a44c68" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c69" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6a" Value="90"/>
+            <Line Type="bytes" Address="0x01a44c6b" Value="90"/>
+            <Line Type="bytes" Address="0x01a452c7" Value="b880070000"/>
+            <Line Type="bytes" Address="0x01a452cc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cd" Value="90"/>
+            <Line Type="bytes" Address="0x01a452ce" Value="90"/>
+            <Line Type="bytes" Address="0x01a452cf" Value="90"/>
+            <Line Type="bytes" Address="0x01a452d0" Value="c4e1fa2ac8"/>
+            <Line Type="bytes" Address="0x01a452d5" Value="b838040000"/>
+            <Line Type="bytes" Address="0x01a452da" Value="90"/>
+            <Line Type="bytes" Address="0x01a452db" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dc" Value="90"/>
+            <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
This is just the patch for shadps4 to enable the highest tested resolution that dosent crash, they are irregular resolutions so wont fill the entire screen for some screens ingame. but gameplay works ok. Also adds the best code for 60 fps cloth physics (credits to Kyo for figuring out which number needed to change to fix the cloths.)