### PR TITLE
Resolution Patches for P3D, P4D, P5D, and P5R

### DIFF
--- a/PATCHES/Persona3_DancingInMoonlight.xml
+++ b/PATCHES/Persona3_DancingInMoonlight.xml
@@ -25,4 +25,46 @@
             <Line Type="mask" Address="E8 ?? ?? ?? ?? 31 C9 85 C0 B8 38 04 00 00" Value="b801000000" Offset="0"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Persona 3: Dancing in Moonlight"
+            Name="Force 1440p (2k) Render Resolution"
+            Note="Forces 1440p (2k) Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005d40b2" Value="b8a0050000"/>
+            <Line Type="bytes" Address="0x005d40e3" Value="b8000a0000"/>
+            <Line Type="bytes" Address="0x0084ea68" Value="0000803e"/>
+            <Line Type="bytes" Address="0x0084ea6c" Value="0000c03e"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 3: Dancing in Moonlight"
+            Name="Force 720p Render Resolution"
+            Note="Forces 720p Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005d40b2" Value="b8d0020000"/>
+            <Line Type="bytes" Address="0x005d40e3" Value="b800050000"/>
+            <Line Type="bytes" Address="0x0084ea68" Value="0000803e"/>
+            <Line Type="bytes" Address="0x0084ea6c" Value="0000403f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 3: Dancing in Moonlight"
+            Name="Force 540p Render Resolution"
+            Note="Forces 540p (Essentially PS Vita's) Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005d40b2" Value="b81c020000"/>
+            <Line Type="bytes" Address="0x005d40e3" Value="b8c0030000"/>
+            <Line Type="bytes" Address="0x0084ea68" Value="0000803e"/>
+            <Line Type="bytes" Address="0x0084ea6c" Value="0000803f"/>
+        </PatchList>
+    </Metadata>
 </Patch>

--- a/PATCHES/Persona4_DancingAllNight.xml
+++ b/PATCHES/Persona4_DancingAllNight.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA12811</ID>
+    </TitleID>
+    <Metadata Title="Persona 4: Dancing All Night"
+            Name="Force 4k Render Resolution"
+            Note="Forces 4k Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0054cbd7" Value="c7442408000f0000"/>
+            <Line Type="bytes" Address="0x0054cbdf" Value="c744240c70080000"/>
+            <Line Type="bytes" Address="0x007d57e0" Value="000f0000"/>
+            <Line Type="bytes" Address="0x007d57e4" Value="70080000"/>
+            <Line Type="bytes" Address="0x007d5800" Value="0000803e"/>
+            <Line Type="bytes" Address="0x007d5804" Value="0000803e"/>
+            <Line Type="bytes" Address="0x007d5808" Value="0000003f"/>
+            <Line Type="bytes" Address="0x007d580c" Value="0000003f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 4: Dancing All Night"
+            Name="Force 1440p (2k) Render Resolution"
+            Note="Forces 1440p (2k) Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0054cbd7" Value="c7442408000a0000"/>
+            <Line Type="bytes" Address="0x0054cbdf" Value="c744240ca0050000"/>
+            <Line Type="bytes" Address="0x007d57e0" Value="000a0000"/>
+            <Line Type="bytes" Address="0x007d57e4" Value="a0050000"/>
+            <Line Type="bytes" Address="0x007d5800" Value="0000c03e"/>
+            <Line Type="bytes" Address="0x007d5804" Value="0000c03e"/>
+            <Line Type="bytes" Address="0x007d5808" Value="0000003f"/>
+            <Line Type="bytes" Address="0x007d580c" Value="0000003f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 4: Dancing All Night"
+            Name="Force 720p Render Resolution"
+            Note="Forces 720p Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0054cbd7" Value="c744240800050000"/>
+            <Line Type="bytes" Address="0x0054cbdf" Value="c744240cd0020000"/>
+            <Line Type="bytes" Address="0x007d57e0" Value="00050000"/>
+            <Line Type="bytes" Address="0x007d57e4" Value="d0020000"/>
+            <Line Type="bytes" Address="0x007d5800" Value="0000403f"/>
+            <Line Type="bytes" Address="0x007d5804" Value="0000403f"/>
+            <Line Type="bytes" Address="0x007d5808" Value="0000003f"/>
+            <Line Type="bytes" Address="0x007d580c" Value="0000003f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 4: Dancing All Night"
+            Name="Force 540p Render Resolution"
+            Note="Forces 540p (Essentially PS Vita's) Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0054cbd7" Value="c7442408c0030000"/>
+            <Line Type="bytes" Address="0x0054cbdf" Value="c744240c1c020000"/>
+            <Line Type="bytes" Address="0x007d57e0" Value="c0030000"/>
+            <Line Type="bytes" Address="0x007d57e4" Value="1c020000"/>
+            <Line Type="bytes" Address="0x007d5800" Value="0000803f"/>
+            <Line Type="bytes" Address="0x007d5804" Value="0000803f"/>
+            <Line Type="bytes" Address="0x007d5808" Value="0000003f"/>
+            <Line Type="bytes" Address="0x007d580c" Value="0000003f"/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/PATCHES/Persona5_DancingInStarlight.xml
+++ b/PATCHES/Persona5_DancingInStarlight.xml
@@ -25,4 +25,46 @@
             <Line Type="mask" Address="E8 ?? ?? ?? ?? 31 C9 85 C0 B8 38 04 00 00" Value="b801000000" Offset="0"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Persona 5: Dancing in Starlight"
+            Name="Force 1440p (2k) Render Resolution"
+            Note="Forces 1440p (2k) Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005d6ba2" Value="b8a0050000"/>
+            <Line Type="bytes" Address="0x005d6bd3" Value="b8000a0000"/>
+            <Line Type="bytes" Address="0x00852e28" Value="0000803e"/>
+            <Line Type="bytes" Address="0x00852e2c" Value="0000c03e"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 5: Dancing in Starlight"
+            Name="Force 720p Render Resolution"
+            Note="Forces 720p Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005d6ba2" Value="b8d0020000"/>
+            <Line Type="bytes" Address="0x005d6bd3" Value="b800050000"/>
+            <Line Type="bytes" Address="0x00852e28" Value="0000803e"/>
+            <Line Type="bytes" Address="0x00852e2c" Value="0000403f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 5: Dancing in Starlight"
+            Name="Force 540p Render Resolution"
+            Note="Forces 540p (Essentially PS Vita's) Render Resolution"
+            Author="Danu"
+            PatchVer="1.0"
+            AppVer="01.00"
+            AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x005d6ba2" Value="b81c020000"/>
+            <Line Type="bytes" Address="0x005d6bd3" Value="b8c0030000"/>
+            <Line Type="bytes" Address="0x00852e28" Value="0000803e"/>
+            <Line Type="bytes" Address="0x00852e2c" Value="0000803f"/>
+        </PatchList>
+    </Metadata>
 </Patch>

--- a/PATCHES/Persona5_Royal.xml
+++ b/PATCHES/Persona5_Royal.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA17416</ID>
+    </TitleID>
+    <Metadata Title="Persona 5 Royal" Name="Force 4k Render Resolution" Note="Forces 4k Render Resolution by triggerring the PS4 Pro check" Author="Danu" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x01851611" Value="b801000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Persona 5 Royal" Name="Force 1440p (2k) Render Resolution" Note="Forces 1440p (2k) Render Resolution" Author="Danu" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x01851621" Value="41b8a0050000"/>
+            <Line Type="bytes" Address="0x0185162c" Value="b8000a0000"/>
+            <Line Type="bytes" Address="0x01bd26d0" Value="00000040"/>
+            <Line Type="bytes" Address="0x01bd26d4" Value="abaaaa3f"/>
+        </PatchList>
+</Patch>


### PR DESCRIPTION
This was a bit annoying to figure out with P4D specifically. I could probably support more regions later once I figure out masks properly.
Provides more resolution options to these games. No PS4 Pro mode required. It is impossible to go below 1080p in P5R because while the resolution can be changed, the UI scaling value cannot go below what is set for 1080p.