### PR TITLE
Add CUSA12112 as a valid Title ID for Persona 4: Dancing All Night

### DIFF
--- a/PATCHES/Persona4_DancingAllNight.xml
+++ b/PATCHES/Persona4_DancingAllNight.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <Patch>
     <TitleID>
+        <ID>CUSA12112</ID>
         <ID>CUSA12811</ID>
     </TitleID>
     <Metadata Title="Persona 4: Dancing All Night"


### PR DESCRIPTION
I have verified that these patches do work on this other Title ID with no other changes required.