### PR TITLE
Updating Bloodborne's resolution patches description 

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1545,6 +1545,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (2560x1440)"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"
@@ -1578,7 +1579,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3200x1800)"
-              Note="High VRAM requirements."
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"
@@ -1612,7 +1613,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3840x2160)"
-              Note="Crashes unless 4090."
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"
@@ -1680,6 +1681,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (2560x1080) (21:9 2.37)"
+              Note="Resolution above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"
@@ -1714,6 +1716,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3440x1440) (21:9 2.38)"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"
@@ -1748,6 +1751,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3840x1080) (32:9 ~3.55)"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"

--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1681,7 +1681,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (2560x1080) (21:9 2.37)"
-              Note="Resolution above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"


### PR DESCRIPTION
Adding a description that states that resolution patches above 1080p (native game resolution) can break the game in various ways, it has been discovered my FMOD on Discord that those patches aren't the problem, it's the PS4 memory limitation, with a proof of concept hack it's possible to use those patches without issues on the emulator, on real hardware (PS4) resolution patches above 1080p crash the game when launching, so in a way the emulator handles those patches better. Can now close issues #15 and #33 as the patches aren't the problem.