### PR TITLE
Add Increased Graphics Heap Sizes Patch to All High Resolution Patches

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1676,6 +1676,8 @@
             <Line Type="bytes" Address="0x01a452db" Value="90"/>
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
@@ -1710,6 +1712,8 @@
             <Line Type="bytes" Address="0x01a452db" Value="90"/>
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
@@ -1744,6 +1748,8 @@
             <Line Type="bytes" Address="0x01a452db" Value="90"/>
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
@@ -1779,6 +1785,8 @@
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
             <Line Type="bytes" Address="0x0183a35d" Value="398ee33f"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
@@ -1882,6 +1890,8 @@
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
             <Line Type="bytes" Address="0x0183a35d" Value="26b41740"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
@@ -1917,6 +1927,8 @@
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
             <Line Type="bytes" Address="0x0183a35d" Value="8ee31840"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
@@ -1952,6 +1964,8 @@
             <Line Type="bytes" Address="0x01a452dc" Value="90"/>
             <Line Type="bytes" Address="0x01a452dd" Value="90"/>
             <Line Type="bytes" Address="0x0183a35d" Value="398e6340"/>
+			<Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"

--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1646,8 +1646,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (2560x1440)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+              Note="Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -1682,8 +1682,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3200x1800)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk. Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -1718,8 +1718,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3840x2160)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk. Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -1754,8 +1754,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (7680x4320)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk. Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -1859,8 +1859,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (2560x1080) (21:9 2.37)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+			  Note="Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -1896,8 +1896,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3440x1440) (21:9 2.38)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk. Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">
@@ -1933,8 +1933,8 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Resolution Patch (3840x1080) (32:9 ~3.55)"
-              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk"
-              Author="xzy"
+              Note="Resolutions above 1080p can break the game (missing geometry, invisible enemies, crashes) because of PS4 memory limitation. Use them at your own risk. Requires 'isDevKit = true' in the shadPS4 config. Needed for resolution patches above 1080p"
+              Author="xzy and auser1337"
               PatchVer="1.0"
               AppVer="01.09"
               AppElf="eboot.bin">


### PR DESCRIPTION
Added the Increased Graphics Heap Sizes patch to all high resolution patches so users don’t have to apply it manually anymore. Also updated the notes for each high resolution to let user know which ones might crash and which require 'isDevKit = true' to work properly.