### PR TITLE
Creating Ratchet and Clank patch file

### DIFF
--- a/PATCHES/Ratchet_and_Clank.xml
+++ b/PATCHES/Ratchet_and_Clank.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA01073</ID>
+        <ID>CUSA01047</ID>
+		<ID>CUSA01928</ID>
+		<ID>CUSA01686</ID>
+		<ID>CUSA02020</ID>
+    </TitleID>
+    <Metadata Title="Ratchet and Clank" 
+			  Name="Bypass hang" 
+			  Note="Skips the hang when creating a new game" 
+			  Author="kalaposfos" 
+			  PatchVer="1.0" 
+			  AppVer="01.09" 
+			  AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x1B5D994" Value="9090"/>
+            <PatchList/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/PATCHES/Ratchet_and_Clank.xml
+++ b/PATCHES/Ratchet_and_Clank.xml
@@ -3,9 +3,9 @@
     <TitleID>
         <ID>CUSA01073</ID>
         <ID>CUSA01047</ID>
-		<ID>CUSA01928</ID>
-		<ID>CUSA01686</ID>
-		<ID>CUSA02020</ID>
+	<ID>CUSA01928</ID>
+	<ID>CUSA01686</ID>
+	<ID>CUSA02020</ID>
     </TitleID>
     <Metadata Title="Ratchet and Clank" 
 			  Name="Bypass hang" 
@@ -16,7 +16,6 @@
 			  AppElf="eboot.bin">
         <PatchList>
             <Line Type="bytes" Address="0x1B5D994" Value="9090"/>
-            <PatchList/>
         </PatchList>
     </Metadata>
 </Patch>


### PR DESCRIPTION
Creating Ratchet and Clank patch file, this patch was tested both on shad and on real hardware, on shad it helps the game get past the hang and on real hardware it doesn't change anything during the same loading screen shad hangs on. If needed I can also add the two patches from Illusion's repo but I wasn't sure what was the opinion of adding other repos patches to the shad repo directly so I didn't do it.