### PR TITLE
Driveclub.xml

### DIFF
--- a/PATCHES/Driveclub.xml
+++ b/PATCHES/Driveclub.xml
@@ -65,6 +65,20 @@
     </Metadata>
 
     <Metadata Title="Driveclub"
+              Name="Resolution patch (5120x1440)"
+              Note="Custom 32:9 QHD patch for ultrawide monitors"
+              Author="YourNameHere"
+              PatchVer="1.0"
+              AppVer="01.28"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0xB29978" Value="66655540" />
+            <Line Type="bytes" Address="0x00b54c1b" Value="00140000" />
+            <Line Type="bytes" Address="0x00b54c21" Value="a0050000" />
+        </PatchList>
+    </Metadata>
+
+    <Metadata Title="Driveclub"
               Name="Resolution patch (1920x1200) (16:10)"
               Note="Original for the PS4 made by u/Charlie_Muggins, extended by kalaposfos to work on shadPS4 too. Disclaimer: Aspect ratios narrower than 16:9 will crop the menu."
               Author="u/Charlie_Muggins, kalaposfos"
@@ -80,7 +94,7 @@
 
     <Metadata Title="Driveclub"
               Name="Run without sysmodules"
-              Note="Spoofs an error return for a stubbed font function.\nThe game will have no text and will take longer to boot."
+              Note="Spoofs an error return for a stubbed font function. The game will have no text and will take longer to boot."
               Author="kalaposfos"
               PatchVer="1.0"
               AppVer="01.28"

--- a/PATCHES/Driveclub.xml
+++ b/PATCHES/Driveclub.xml
@@ -7,6 +7,7 @@
         <ID>CUSA00093</ID>
         <ID>CUSA00879</ID>
     </TitleID>
+
     <Metadata Title="Driveclub" 
               Name="60 FPS" 
               Note="Patch version 2.0 features deltatime." 
@@ -20,6 +21,7 @@
             <Line Type="bytes" Address="0x00a6306e" Value="9090"/>
         </PatchList>
     </Metadata>
+
     <Metadata Title="Driveclub"
               Name="Resolution patch (2560x1080)"
               Note="Original for the PS4 made by u/Charlie_Muggins, extended by kalaposfos to work on shadPS4 too"
@@ -33,6 +35,7 @@
             <Line Type="bytes" Address="0x00b54c21" Value="38040000"/>
         </PatchList>
     </Metadata>
+
     <Metadata Title="Driveclub"
               Name="Resolution patch (3840x1080)"
               Note="Original for the PS4 made by u/Charlie_Muggins, extended by kalaposfos to work on shadPS4 too"
@@ -46,6 +49,21 @@
             <Line Type="bytes" Address="0x00b54c21" Value="38040000" />
         </PatchList>
     </Metadata>
+
+    <Metadata Title="Driveclub"
+              Name="Resolution patch (5120x1080)"
+              Note="Custom ultrawide patch for 32:9 monitors; optimized for 1080p output"
+              Author="YourNameHere"
+              PatchVer="1.0"
+              AppVer="01.28"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0xB29978" Value="8f969740" />
+            <Line Type="bytes" Address="0x00b54c1b" Value="00140000" />
+            <Line Type="bytes" Address="0x00b54c21" Value="38040000" />
+        </PatchList>
+    </Metadata>
+
     <Metadata Title="Driveclub"
               Name="Resolution patch (1920x1200) (16:10)"
               Note="Original for the PS4 made by u/Charlie_Muggins, extended by kalaposfos to work on shadPS4 too. Disclaimer: Aspect ratios narrower than 16:9 will crop the menu."
@@ -59,6 +77,7 @@
             <Line Type="bytes" Address="0x00b54c21" Value="b0040000" />
         </PatchList>
     </Metadata>
+
     <Metadata Title="Driveclub"
               Name="Run without sysmodules"
               Note="Spoofs an error return for a stubbed font function.\nThe game will have no text and will take longer to boot."


### PR DESCRIPTION
This patch modifies Driveclub’s internal rendering resolution to 5120x1080, matching ultra-wide 32:9 displays such as super ultrawide monitors (e.g., Samsung Odyssey G9). While the PlayStation 4 natively outputs at a maximum of 1920x1080 (1080p), this patch forces the internal framebuffer and camera FOV to render at the wider 5120x1080 resolution.

⚠️ Important Notes:

    The game will still output at 1080p unless used on a PS4 emulator or hardware that allows native framebuffer scaling or EDID spoofing.

    This patch ensures that the entire field of view is widened, which results in improved peripheral vision and a more immersive driving experience — especially valuable in cockpit view.

    HUD and UI elements may stretch or misalign, as they were designed for 16:9. Menus and overlays may appear cut off or improperly scaled.

    Performance may degrade depending on how your environment handles the increased internal render resolution. Pairing this patch with the included 60 FPS unlock is recommended for smoother gameplay.