### PR TITLE
Creating TheLastGuardian.xml

### DIFF
--- a/TheLastGuardian.xml
+++ b/TheLastGuardian.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA03627</ID>
+        <ID>CUSA03745</ID>
+        <ID>CUSA04936</ID>
+    </TitleID>
+    <Metadata Title="The Last Gurdian" Name="60 FPS Unlock" Note="Currently doesn't work" Author="illusion" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01051467" Value="e9b3000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Last Guardian" Name="Resolution Patch: Native 640x360" Note="You need to change your Window Size in the emulator settings to a resolution over 1920x1080 for the resolution patches to work" Author="illusion" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes64" Address="0x01aec3e8" Value="0x0168028001680280"/>
+            <Line Type="bytes64" Address="0x01aec3f0" Value="0x0000000000000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Last Guardian" Name="Resolution Patch: Native 1280x720" Note="You need to change your Window Size in the emulator settings to a resolution over 1920x1080 for the resolution patches to work" Author="illusion" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes64" Address="0x01aec3e8" Value="0x02D0050002D00500"/>
+            <Line Type="bytes64" Address="0x01aec3f0" Value="0x0000000000000000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Last Guardian" Name="Resolution Patch: Native 3840x2160" Note="You need to change your Window Size in the emulator settings to a resolution over 1920x1080 for the resolution patches to work" Author="illusion" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes64" Address="0x01aec3e8" Value="0x08700f0008700f00"/>
+            <Line Type="bytes64" Address="0x01aec3f0" Value="0x0000000000000000"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
Creating TheLastGuardian.xml, adds two resolution patches (720p and 360p for performance purposes) and changes the note of the already existing patches. Didn't add 1440p as the resolution didn't work so useless atm, and still need to wait until @kalaposfos13 testing to merge so opening as a draft.