### PR TITLE
Adding issue templates for game patches

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch-bug-report
+++ b/.github/ISSUE_TEMPLATE/patch-bug-report
@@ -1,0 +1,3 @@
+name: Patch Bug Report
+description: Problem with one of the patch (not behaving as expected, causing crashes ...)
+title: "[Patch Bug]: "

--- a/.github/ISSUE_TEMPLATE/patch-request.yaml
+++ b/.github/ISSUE_TEMPLATE/patch-request.yaml
@@ -1,0 +1,3 @@
+name: Patch Request
+description: Suggest a new patch
+title: "[Patch Request]: "


### PR DESCRIPTION
Adding issue templates for game patches based on the current issue templates of the main repo of shadPS4 (so all credit to the original creator, I think it was Roamic but I'm not sure). Opening as a draft as they're currently just placeholdersand also because I want to hear opinions on this, if this is fine I'll continue, if not I'll just close it. I also thought of doing the same for cheats but there's currently only cheats for BB and most of them aren't even working (I might take a look at those one day and remove the ones that don't work).