### PR TITLE
60 FPS patch for Driveclub, with engine bugs fixed

### DIFF
--- a/PATCHES/Driveclub.xml
+++ b/PATCHES/Driveclub.xml
@@ -8,8 +8,8 @@
         <ID>CUSA00879</ID>
     </TitleID>
     <Metadata Title="Driveclub" 
-              Name="60 FPS" 
-              Note="Patch version 2.0 features deltatime." 
+              Name="60 FPS with deltatime" 
+              Note="Patch version 2.0 features deltatime. this version will break some things in the game, if that is an issue for you, use the other 60 FPS patch." 
               Author="illusion, u/Charlie_Muggins" 
               PatchVer="2.0" 
               AppVer="01.28" 
@@ -21,7 +21,7 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Driveclub"
-              Name="60 FPS by kalaposfos"
+              Name="60 FPS with fixed tickrate"
               Note="Enables 60 FPS with the engine's builtin way to do it, making this version work with features that break with the other 60 FPS patch enabled."
               Author="kalaposfos"
               PatchVer="1.0"

--- a/PATCHES/Driveclub.xml
+++ b/PATCHES/Driveclub.xml
@@ -21,6 +21,17 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Driveclub"
+              Name="60 FPS by kalaposfos"
+              Note="Enables 60 FPS with the engine's builtin way to do it, making this version work with features that break with the other 60 FPS patch enabled."
+              Author="kalaposfos"
+              PatchVer="1.0"
+              AppVer="01.28"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01762801" Value="67" />
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Driveclub"
               Name="Resolution patch (2560x1080)"
               Note="Original for the PS4 made by u/Charlie_Muggins, extended by kalaposfos to work on shadPS4 too"
               Author="u/Charlie_Muggins, kalaposfos"


### PR DESCRIPTION
This achieves the exact same result as what would happen if you set `RenderOptions.Set("fixedFramesPerSecond", 60)` in the lua bootscript that the game uses, making the issues present in the other 60 FPS patch fixed. I'm not sure about whether or not I should remove the old patch though, or what would be an appropriate name for the new patch, so I'm opening a PR for it instead of committing directly to main. Feedback on these questions are welcome.