### PR TITLE
[Catherine] Removed old initializer fix

### DIFF
--- a/PATCHES/Catherine_FullBody.xml
+++ b/PATCHES/Catherine_FullBody.xml
@@ -4,16 +4,6 @@
         <ID>CUSA14836</ID>
         <ID>CUSA15036</ID>
     </TitleID>
-    <Metadata Title="Catherine: Full Body" Name="Initializer Fix" Note="Patch broken calls which prevent game from launching" Author="marecl" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin">
-        <PatchList>
-            <Line Type="bytes" Address="0x46CF84" Value="9090909090"/>
-        </PatchList>
-    </Metadata>
-    <Metadata Title="Catherine: Full Body" Name="Initializer Fix" Note="Patch broken calls which prevent game from launching" Author="marecl" PatchVer="1.0" AppVer="01.01" AppElf="eboot.bin">
-        <PatchList>
-            <Line Type="bytes" Address="0x46CF84" Value="9090909090"/>
-        </PatchList>
-    </Metadata>
     <Metadata Title="Catherine: Full Body" Name="SkipIntro" Note="Skip Intro" Author="marecl" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin">
         <PatchList>
             <Line Type="bytes" Address="0x787970" Value="9090909090"/>


### PR DESCRIPTION
Fix has been deployed to shad, so this is no longer required for the game to run.