### PR TITLE
Bloodborne: add Intel 12th gen crash workaround

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -110,6 +110,17 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne" 
+              Name="Intel 12th Gen+ SFX Fix" 
+              Note="Disables part of SFX related code to workaround crash on newer Intel chips (SFX folder can be used with patch)" 
+              Author="emoose" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte" Address="0x02CF83E0" Value="c3"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
               Name="Light Grid Div 0x0" 
               Author="hspir404" 
               PatchVer="1.0" 

--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -111,7 +111,7 @@
     </Metadata>
     <Metadata Title="Bloodborne" 
               Name="Intel 12th Gen+ SFX Fix" 
-              Note="Disables part of SFX related code to workaround crash on newer Intel chips (SFX folder can be used with patch)" 
+              Note="Disables part of SFX related code to workaround crash on Windows with newer Intel chips (SFX folder can be used with patch)" 
               Author="emoose" 
               PatchVer="1.0" 
               AppVer="01.09" 


### PR DESCRIPTION
Adds a patch that can workaround the crash issue with sfx on Intel 12th gen+.

Patching out the func that crashes with `ret` resulted in some gfx issues, tried patching the caller of it but that was the same, but patching the caller of that (the caller's caller) seems to fix the crash without any apparent graphics issues.
AFAIK this caller-func is only ran when the SFX that has issues is about to be used, don't think it should affect things outside of SFX.

Also works with the `sfx` folder in place too, would guess this is probably disabling some part of sfx, but @Missake212 has mentioned that sfx mostly still works as it should with this.

(more info: https://github.com/shadps4-emu/shadPS4/issues/1641#issuecomment-3146656166)

Thanks to @Missake212 and @bigol83 for testing.