### PR TITLE
Changing the disable vsync patch description

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -494,7 +494,7 @@
     </Metadata>
     <Metadata Title="Bloodborne"
               Name="Disable vsync"
-	          Note="This patch shouldn't be used without the 60 FPS (With Deltatime) patch"
+	          Note="This patch disables vsync to play ABOVE 60 FPS. Needs to be used with the 60 FPS patch and Vblank Divider set to 2 in the settings"
               Author="illusion"
               PatchVer="1.0"
               AppVer="01.09"


### PR DESCRIPTION
Seeing too many people use this patch with vblank set to 1, so the patch is enabled for no reason, hoping to make people aware that this patch is made to play at OVER 60 FPS and that you don't need it to play at 60 FPS.