### PR TITLE
Creating The Order: 1886 patch

### DIFF
--- a/PATCHES/TheOrder1886.xml
+++ b/PATCHES/TheOrder1886.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA00035</ID>
+        <ID>CUSA00070</ID>
+        <ID>CUSA00076</ID>
+        <ID>CUSA00100</ID>
+        <ID>CUSA00670</ID>
+        <ID>CUSA00785</ID>
+    </TitleID>
+    <Metadata Title="The Order 1886" Name="60 FPS Unlock" Note="Softlocks will occur in Chapter 6 and 9 during Quick Time Events.\nDisable patch to progress." Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte" Address="0x008507c4" Value="0x01"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Order 1886" Name="Resolution Patch (4K)" Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte" Address="0x0084cef5" Value="0x75"/>
+            <Line Type="bytes32" Address="0x0084cefd" Value="0x00000F00"/>
+            <Line Type="bytes32" Address="0x0084cf07" Value="0x00000870"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Order 1886" Name="Resolution Patch (1440p)" Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte" Address="0x0084cef5" Value="0x75"/>
+            <Line Type="bytes32" Address="0x0084cefd" Value="0x00000A00"/>
+            <Line Type="bytes32" Address="0x0084cf07" Value="0x000005A0"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Order 1886" Name="Resolution Patch (900p)" Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte" Address="0x0084cef5" Value="0x75"/>
+            <Line Type="bytes32" Address="0x0084cefd" Value="0x00000640"/>
+            <Line Type="bytes32" Address="0x0084cf07" Value="0x00000384"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Order 1886" Name="Resolution Patch (720p)" Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="byte" Address="0x0084cef5" Value="0x75"/>
+            <Line Type="bytes32" Address="0x0084cefd" Value="0x00000500"/>
+            <Line Type="bytes32" Address="0x0084cf07" Value="0x000002d0"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="The Order 1886" Name="16:9 Aspect Ratio (Full Screen)" Note="Native 1080p will cause visual issues, 900p or below must be used." Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes32" Address="0x0084ce8c" Value="0x3fe38e39"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
Creating The Order: 1886 patch based on the patch on the GoldHEN repo, decided to keep everything from the original patch for now to see what we keep and what we deleted, I also added a 1440p and a 4K patch based on the existing res patch and tried them out on the emulator, game boots normally and the frame info says the game is displaying the proper res, not sure how it looks in gameplay though. In my opinion we can probably get rid of the 900p, 720p and the aspect ratio patch.