### PR TITLE
Add 60 fps patch and debug menu to R&C

### DIFF
--- a/PATCHES/Ratchet_and_Clank.xml
+++ b/PATCHES/Ratchet_and_Clank.xml
@@ -17,4 +17,17 @@
             <Line Type="bytes" Address="0x1B5CB14" Value="9090"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Ratchet and Clank" Name="60 FPS Unlock" Author="illusion" PatchVer="1.0" AppVer="01.09" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01b23444" Value="4d69fc48010000"/>
+            <Line Type="bytes" Address="0x01b2344b" Value="6641c7461e803f"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Ratchet and Clank" Name="Debug Menu" Author="Lance McDonald (manfightdragon)" PatchVer="1.0" AppVer="01.09" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x006e2ae5" Value="803534a8740401"/>
+            <Line Type="bytes" Address="0x006e2aec" Value="9090"/>
+        </PatchList>
+    </Metadata>
 </Patch>
+

--- a/PATCHES/Ratchet_and_Clank.xml
+++ b/PATCHES/Ratchet_and_Clank.xml
@@ -30,4 +30,3 @@
         </PatchList>
     </Metadata>
 </Patch>
-

--- a/PATCHES/TheOrder1886.xml
+++ b/PATCHES/TheOrder1886.xml
@@ -13,14 +13,14 @@
             <Line Type="byte" Address="0x008507c4" Value="0x01"/>
         </PatchList>
     </Metadata>
-    <Metadata Title="The Order 1886" Name="Resolution Patch (4K)" Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+    <Metadata Title="The Order 1886" Name="Resolution Patch (4K)" Author="illusion" Note="This patch doesn't seem to work currently." PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
         <PatchList>
             <Line Type="byte" Address="0x0084cef5" Value="0x75"/>
             <Line Type="bytes32" Address="0x0084cefd" Value="0x00000F00"/>
             <Line Type="bytes32" Address="0x0084cf07" Value="0x00000870"/>
         </PatchList>
     </Metadata>
-    <Metadata Title="The Order 1886" Name="Resolution Patch (1440p)" Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
+    <Metadata Title="The Order 1886" Name="Resolution Patch (1440p)" Note="This patch doesn't seem to work currently." Author="illusion" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin">
         <PatchList>
             <Line Type="byte" Address="0x0084cef5" Value="0x75"/>
             <Line Type="bytes32" Address="0x0084cefd" Value="0x00000A00"/>
@@ -47,3 +47,4 @@
         </PatchList>
     </Metadata>
 </Patch>
+

--- a/PATCHES/TheOrder1886.xml
+++ b/PATCHES/TheOrder1886.xml
@@ -47,4 +47,3 @@
         </PatchList>
     </Metadata>
 </Patch>
-


### PR DESCRIPTION
Added 60 fps patch and debug menu to R&C, also decided to add a description to the resolution patches for The Order 1886 as they seem to not function properly and might need additional tweaking, in my brief testing they crash on different errors, instead of deleting the whole file I decided to add a description for now and hope we can investigate it later to see what do these patches need.