### PR TITLE
Ratchet and Clank: 1440p resolution patch

### DIFF
--- a/PATCHES/Ratchet_and_Clank.xml
+++ b/PATCHES/Ratchet_and_Clank.xml
@@ -27,4 +27,11 @@
             <Line Type="bytes" Address="0x006e2aec" Value="9090"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Ratchet and Clank" Name="Resolution 2560x1440" Author="ricnava00" PatchVer="1.0" AppVer="01.09" AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01c4a9f2" Value="9090"/>
+            <Line Type="bytes" Address="0x01c4a9f4" Value="48b8000a0000a0050000"/>
+        </PatchList>
+    </Metadata>
 </Patch>
+


### PR DESCRIPTION
The game already natively tries to set the resolution to 2160p if the internal height is > 1080
This patch skips the condition check, and sets the resolution to 1440p instead

For some reason (maybe memory size?), in the current emulator version, using 2160p (either by setting the internal height as 2160 in the config, or by keeping only the first line of the patch) crashes the game, but 1440p works