### PR TITLE
Rename Light Grid patch for Bloodborne

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -69,7 +69,8 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne" 
-              Name="Light Grid Div 0x0" 
+              Name="Disable Dynamic Lighting (Performance Increase)" 
+			  Note="Sets light grid to 0x0 which effectively disables dynamic lighting.\nReduces visual quality but increases performance." 
               Author="hspir404" 
               PatchVer="1.0" 
               AppVer="01.09" 


### PR DESCRIPTION
Many users aren't really aware what setting the light grid division to 0x0 means, so this should make it more clear as to what the purpose of said patch is.