### PR TITLE
Update Bloodborne.xml

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -49,12 +49,51 @@
               AppVer="01.09" 
               AppElf="eboot.bin">
         <PatchList>
-            <Line Type="bytes" Address="0x0553b124" Value="14"/>
-            <Line Type="bytes" Address="0x0553b128" Value="14"/>
+            <Line Type="bytes" Address="0x0553b124" Value="1"/>
+            <Line Type="bytes" Address="0x0553b128" Value="0"/>
             <Line Type="bytes" Address="0x0553b134" Value="0"/>
             <Line Type="bytes" Address="0x0553b1a0" Value="0"/>
-            <Line Type="bytes" Address="0x0553b18c" Value="01"/>
-            <Line Type="bytes" Address="0x0553b198" Value="01"/>
+            <Line Type="bytes" Address="0x0553b18c" Value="1"/>
+            <Line Type="bytes" Address="0x0553b198" Value="1"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Model LOD 2 (Lowest)" 
+              Note="Lowest model detail, performance increase. Affects visuals, lower Model LOD." 
+              Author="Kyo, auser1337" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0216fc09" Value="b90200000090"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Model LOD 1 (Lower)" 
+              Note="Slightly lower model detail, performance increase. Affects visuals, lower Model LOD." 
+              Author="Kyo, auser1337" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0216fc09" Value="b90100000090"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" 
+              Name="Model LOD -2 (Highest)" 
+              Note="Highest model detail, performance increase. Affects visuals, Higher model LOD." 
+              Author="Kyo, auser1337" 
+              PatchVer="1.0" 
+              AppVer="01.09" 
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0216fc09" Value="b9FEFFFFFF90"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne" Name="Increased Graphics Heap Sizes" Author="auser1337" Note="This patch increases the graphic heap size, \nallowing more memory to be used. \nMUST BE USED WITH INCREASED DMEM. \nkeep in mind this is already in resolution patches above 1080p,\nbut some users requested it seperately. " PatchVer="1.0" AppVer="01.09" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x04b36dda" Value="00f7"/>
+            <Line Type="bytes" Address="0x04b36de2" Value="00a0"/>
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne" 
@@ -196,6 +235,116 @@
             <Line Type="bytes" Address="0x02418e50" Value="90"/>
             <Line Type="bytes" Address="0x02418e51" Value="90"/>
             <Line Type="bytes" Address="0x02418e52" Value="90"/>
+            <Line Type="bytes" Address="0x02418e53" Value="90"/>
+            <Line Type="bytes" Address="0x02418e54" Value="90"/>
+            <Line Type="bytes" Address="0x02418e55" Value="90"/>
+            <Line Type="bytes" Address="0x02418e56" Value="90"/>
+            <Line Type="bytes" Address="0x02418e57" Value="90"/>
+            <Line Type="bytes" Address="0x02418e58" Value="90"/>
+            <Line Type="bytes" Address="0x02418e59" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5a" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5b" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5c" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5d" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5e" Value="90"/>
+            <Line Type="bytes" Address="0x02418e5f" Value="90"/>
+            <Line Type="bytes" Address="0x02418e60" Value="90"/>
+            <Line Type="bytes" Address="0x02418e61" Value="90"/>
+            <Line Type="bytes" Address="0x02418e62" Value="90"/>
+            <Line Type="bytes" Address="0x02418e63" Value="90"/>
+            <Line Type="bytes" Address="0x02418e64" Value="488d05a5765203"/>
+            <Line Type="bytes" Address="0x0243487e" Value="41c74424188988883c"/>
+            <Line Type="bytes" Address="0x02434887" Value="48b90000000001000000"/>
+            <Line Type="bytes" Address="0x02483ec1" Value="c3"/>
+            <Line Type="bytes" Address="0x02483ec2" Value="90"/>
+            <Line Type="bytes" Address="0x02483ec3" Value="90"/>
+            <Line Type="bytes" Address="0x02483ec4" Value="90"/>
+            <Line Type="bytes" Address="0x02483ec5" Value="90"/>
+            <Line Type="bytes" Address="0x02715d71" Value="e881090000"/>
+            <Line Type="bytes" Address="0x02715d76" Value="90"/>
+            <Line Type="bytes" Address="0x02715d77" Value="90"/>
+            <Line Type="bytes" Address="0x02715d78" Value="90"/>
+            <Line Type="bytes" Address="0x02fbf178" Value="4831c0c3"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Bloodborne"
+              Name="60 FPS (With Deltatime) + (Deltatime clamp)"
+              Note="Clamps Deltatime to 60 frames. \nIncreasing performance, smoother emulating, loading, etc. \nRagdolls+Cloth physics normalized at 60 frames. \nThe only downside to this patch is you MUST maintain 60 fps.\nIf your frames drop below 60, then the gamespeed also decreases."
+              Author="Lance McDonald (manfightdragon), Kyo, emoose"
+              PatchVer="1.3"
+              AppVer="01.09"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x00fbc40f" Value="eb1d"/>
+            <Line Type="bytes" Address="0x013d2e16" Value="eb19"/>
+            <Line Type="bytes" Address="0x013d2e18" Value="4156"/>
+            <Line Type="bytes" Address="0x013d2e1a" Value="41c746080000803f"/>
+            <Line Type="bytes" Address="0x013d2e22" Value="c4c17a5e4608"/>
+            <Line Type="bytes" Address="0x013d2e28" Value="415e"/>
+            <Line Type="bytes" Address="0x013d2e2a" Value="e933070000"/>
+            <Line Type="bytes" Address="0x013d2e2f" Value="90"/>
+            <Line Type="bytes" Address="0x013d2e30" Value="90"/>
+            <Line Type="bytes" Address="0x013d3557" Value="c4c17a104608"/>
+            <Line Type="bytes" Address="0x013d355d" Value="e9b6f8ffff"/>
+            <Line Type="bytes" Address="0x01bf9b71" Value="e933010000"/>
+            <Line Type="bytes" Address="0x01bf9b76" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9b77" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ca9" Value="488d054868d403"/>
+            <Line Type="bytes" Address="0x01bf9cb0" Value="488b00"/>
+            <Line Type="bytes" Address="0x01bf9cb3" Value="c745b8"/>
+            <Line Type="bytes" Address="0x01bf9cb6" Value="8988883c"/>
+            <Line Type="bytes" Address="0x01bf9cba" Value="f30f108864020000"/>
+            <Line Type="bytes" Address="0x01bf9cc2" Value="f30f1045b8"/>
+            <Line Type="bytes" Address="0x01bf9cc7" Value="f30f5dc1"/>
+            <Line Type="bytes" Address="0x01bf9ccb" Value="f30f1145b8"/>
+            <Line Type="bytes" Address="0x01bf9cd0" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cd1" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cd2" Value="e9a1feffff"/>
+            <Line Type="bytes" Address="0x021bc181" Value="488d3d70437803"/>
+            <Line Type="bytes" Address="0x021bc188" Value="488b3f"/>
+            <Line Type="bytes" Address="0x021bc18b" Value="c5fa598764020000"/>
+            <Line Type="bytes" Address="0x021bc193" Value="90"/>
+            <Line Type="bytes" Address="0x021bc194" Value="90"/>
+            <Line Type="bytes" Address="0x021bc195" Value="90"/>
+            <Line Type="bytes" Address="0x021bc196" Value="90"/>
+            <Line Type="bytes" Address="0x021bc197" Value="90"/>
+            <Line Type="bytes" Address="0x021bc198" Value="90"/>
+            <Line Type="bytes" Address="0x021bc199" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19a" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19b" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19c" Value="90"/>
+            <Line Type="bytes" Address="0x021bc19d" Value="e96e010000"/>
+            <Line Type="bytes" Address="0x021bc308" Value="e974feffff"/>
+            <Line Type="bytes" Address="0x021bc30d" Value="90"/>
+            <Line Type="bytes" Address="0x021bc30e" Value="90"/>
+            <Line Type="bytes" Address="0x021bc30f" Value="90"/>
+            <Line Type="bytes" Address="0x02377cea" Value="eb24"/>
+            <Line Type="bytes" Address="0x02377cec" Value="488d1d05885c03"/>
+            <Line Type="bytes" Address="0x02377cf3" Value="488b1b"/>
+            <Line Type="bytes" Address="0x02377cf6" Value="c5fa108364020000"/>
+            <Line Type="bytes" Address="0x02377cfe" Value="90"/>
+            <Line Type="bytes" Address="0x02377cff" Value="90"/>
+            <Line Type="bytes" Address="0x02377d00" Value="90"/>
+            <Line Type="bytes" Address="0x02377d01" Value="90"/>
+            <Line Type="bytes" Address="0x02377d02" Value="90"/>
+            <Line Type="bytes" Address="0x02377d03" Value="90"/>
+            <Line Type="bytes" Address="0x02377d04" Value="90"/>
+            <Line Type="bytes" Address="0x02377d05" Value="90"/>
+            <Line Type="bytes" Address="0x02377d06" Value="90"/>
+            <Line Type="bytes" Address="0x02377d07" Value="90"/>
+            <Line Type="bytes" Address="0x02377d08" Value="90"/>
+            <Line Type="bytes" Address="0x02377d09" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0a" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0b" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0c" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0d" Value="90"/>
+            <Line Type="bytes" Address="0x02377d0e" Value="eb42"/>
+            <Line Type="bytes" Address="0x02377d48" Value="eba2"/>
+            <Line Type="bytes" Address="0x02418E39" Value="8988883c"/>
+            <Line Type="bytes" Address="0x02418e3d" Value="f30f108b64020000"/>
+            <Line Type="bytes" Address="0x02418e45" Value="f30f1045c8"/>
+            <Line Type="bytes" Address="0x02418e4a" Value="f30f5dc1"/>
+            <Line Type="bytes" Address="0x02418e4e" Value="f30f1145c8"/>
             <Line Type="bytes" Address="0x02418e53" Value="90"/>
             <Line Type="bytes" Address="0x02418e54" Value="90"/>
             <Line Type="bytes" Address="0x02418e55" Value="90"/>


### PR DESCRIPTION
-Added a few LOD additions.
Model LOD -2 (Lowest model LOD, boosts performance.)
Model LOD -1 (Lower model LOD, boosts performance.
 Model LOD  2 (Highest model LOD, boosts performance.)

-Added a new 60 fps patch version that incorporates a 60 frame clamp to deltatime (thanks to https://github.com/emoose) 

-Added back the Graphic Heap patch.
users were requesting it to be added as it was incorporated into resolution patches above 1080p, which leaves you unavailable to use it with base 1080p resolution or lower. (helps with lag/stutters once caching data, instead of clearing them for newer cached data).

-Modified the Tasksplit patch with more performant values (hopefully, atleast from testing).