### PR TITLE
Add description for Ultrawide patches

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1134,8 +1134,8 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne"
-              Name="Resolution Patch (1280x960) (4:3 ~1.33). "
-		      Note="As the game wasn't made to be played at aspect ratio different than 16:9 some issues may appear (mostly UI related), a mod (called 16x10 and 4x3 UI Fixes (Steam Deck)) to workaround that issue is available on Nexusmods"
+              Name="Resolution Patch (1280x960) (4:3 ~1.33)"
+		      Note="As the game wasn't made to be played at aspect ratio different than 16:9 some issues may appear (mostly UI related), a mod (called 16x10 and 4x3 UI Fixes (Steam Deck)) to workaround that issue is available on Nexusmods."
               Author="xzy"
               PatchVer="1.0"
               AppVer="01.09"


### PR DESCRIPTION
Add a proper description for Ultra wide patches mentioning the UI issues they can face and recommending a mod that works around those issues. Also deleted the 1706x720 patch since it seems to be completely useless, couldn't find any monitor with that resolution. Patch list is still too bloated in my opinion.