### PR TITLE
Delete disable dynamic lighting patch

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -108,18 +108,6 @@
         </PatchList>
     </Metadata>
     <Metadata Title="Bloodborne" 
-              Name="Disable Dynamic Lighting (Performance Increase)" 
-			  Note="Sets light grid to 0x0 which effectively disables dynamic lighting.\nReduces visual quality but increases performance." 
-              Author="hspir404" 
-              PatchVer="1.0" 
-              AppVer="01.09" 
-              AppElf="eboot.bin">
-        <PatchList>
-            <Line Type="bytes32" Address="0x0553ae80" Value="0x00000000"/>
-            <Line Type="bytes32" Address="0x0553ae84" Value="0x00000000"/>
-        </PatchList>
-    </Metadata>
-    <Metadata Title="Bloodborne" 
               Name="Disable HTTP Requests" 
               Author="bloo" 
               PatchVer="1.0" 


### PR DESCRIPTION
Fixes #87 

Like it was said in the issue, the patch increases performance by disabling dynamic lighting, making the game way too dark in some places (like the Hunter's Dream for example), I don't think there's any use out of a patch like that, especially since performance has gotten better recently.