### PR TITLE
Update Bloodborne.xml

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -263,7 +263,8 @@
               AppVer="01.09"
               AppElf="eboot.bin">
         <PatchList>
-			<Line Type="bytes32" Address="0x02434806" Value="0x08516348"/>
+            <Line Type="bytes32" Address="0x02434806" Value="0x08516348"/>
+            <Line Type="bytes" Address="0x0203482f" Value="eb56"/>
             <Line Type="bytes" Address="0x00fbc40f" Value="eb1d"/>
             <Line Type="bytes" Address="0x013d2e16" Value="eb19"/>
             <Line Type="bytes" Address="0x013d2e18" Value="4156"/>
@@ -286,6 +287,28 @@
             <Line Type="bytes" Address="0x01bf9cc2" Value="f30f1045b8"/>
             <Line Type="bytes" Address="0x01bf9cc7" Value="f30f5dc1"/>
             <Line Type="bytes" Address="0x01bf9ccb" Value="f30f1145b8"/>
+            <Line Type="bytes" Address="0x01bf9cb3" Value="8b8064020000"/>
+            <Line Type="bytes" Address="0x01bf9cb9" Value="8945b8"/>
+            <Line Type="bytes" Address="0x01bf9cbc" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cbd" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cbe" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cbf" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc0" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc1" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc2" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc3" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc4" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc5" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc6" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc7" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc8" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cc9" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cca" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccb" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccc" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccd" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9cce" Value="90"/>
+            <Line Type="bytes" Address="0x01bf9ccf" Value="90"/>
             <Line Type="bytes" Address="0x01bf9cd0" Value="90"/>
             <Line Type="bytes" Address="0x01bf9cd1" Value="90"/>
             <Line Type="bytes" Address="0x01bf9cd2" Value="e9a1feffff"/>
@@ -334,6 +357,21 @@
             <Line Type="bytes" Address="0x02418e45" Value="f30f1045c8"/>
             <Line Type="bytes" Address="0x02418e4a" Value="f30f5dc1"/>
             <Line Type="bytes" Address="0x02418e4e" Value="f30f1145c8"/>
+            <Line Type="bytes" Address="0x02418e3d" Value="8b8364020000"/>
+            <Line Type="bytes" Address="0x02418e43" Value="8945c8"/>
+            <Line Type="bytes" Address="0x02418e46" Value="90"/>
+            <Line Type="bytes" Address="0x02418e47" Value="90"/>
+            <Line Type="bytes" Address="0x02418e48" Value="90"/>
+            <Line Type="bytes" Address="0x02418e49" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4a" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4b" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4c" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4d" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4e" Value="90"/>
+            <Line Type="bytes" Address="0x02418e4f" Value="90"/>
+            <Line Type="bytes" Address="0x02418e50" Value="90"/>
+            <Line Type="bytes" Address="0x02418e51" Value="90"/>
+            <Line Type="bytes" Address="0x02418e52" Value="90"/>
             <Line Type="bytes" Address="0x02418e53" Value="90"/>
             <Line Type="bytes" Address="0x02418e54" Value="90"/>
             <Line Type="bytes" Address="0x02418e55" Value="90"/>


### PR DESCRIPTION
minor update, updated the lines to better reflect the newer 60 fps patch, changed the fps limit to be 480 instead of 60, with correct address.
