### PR TITLE
Burnout Paradise Remastered - Skip Logo Videos and intro - 1.03

### DIFF
--- a/PATCHES/BurnoutParadiseRemastered.xml
+++ b/PATCHES/BurnoutParadiseRemastered.xml
@@ -10,7 +10,7 @@
               Author="DanielSvoboda" 
               PatchVer="1.0" 
               AppVer="01.03" 
-              AppElf="eboot.bin"
+              AppElf="eboot.bin">
         <PatchList>
             <Line Type="bytes" Address="0x815DCA" Value="909090909090"/>	<!-- EAFRANCHISE, CRITERION -->
             <Line Type="bytes" Address="0x868310" Value="9090909090"/>		<!-- INTRO -->

--- a/PATCHES/BurnoutParadiseRemastered.xml
+++ b/PATCHES/BurnoutParadiseRemastered.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA10851</ID>
+        <ID>CUSA10866</ID>		
+    </TitleID>
+    <Metadata Title="Burnout Paradise Remastered" 
+              Name="Skip Logo Videos and Intro" 
+              Note="The intro videos freeze at the end in ShadPs4, so this patch skips them." 
+              Author="DanielSvoboda" 
+              PatchVer="1.0" 
+              AppVer="01.03" 
+              AppElf="eboot.bin"
+        <PatchList>
+            <Line Type="bytes" Address="0x815DCA" Value="909090909090"/>	<!-- EAFRANCHISE, CRITERION -->
+            <Line Type="bytes" Address="0x868310" Value="9090909090"/>		<!-- INTRO -->
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
The intro videos freeze at the end in ShadPs4, so this patch skips them.

<img width="1282" height="721" alt="image" src="https://github.com/user-attachments/assets/9b0dc2b4-dd68-4ae7-87f9-fc2218de9381" />
