### PR TITLE
Dark Souls III - Developer Debug Menu - 1.15

### DIFF
--- a/PATCHES/DarkSoulsIII-Orbis.xml
+++ b/PATCHES/DarkSoulsIII-Orbis.xml
@@ -56,4 +56,15 @@
             <Line Type="bytes" Address="0x1392943" Value="b201"/>
         </PatchList>
     </Metadata>
+    <Metadata Title="Dark Souls III"
+              Name="Developer Debug Menu"
+              Note="Left touchpad to open"
+              Author="Whitehawkx, DanielSvoboda"
+              PatchVer="1.0"
+              AppVer="01.15"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x1C01BD7" Value="01"/>
+        </PatchList>
+    </Metadata>
 </Patch>


### PR DESCRIPTION
When I press the left touchpad to open it, the game crashes; so, the patch for enabling the debug menu is correct, but a crash occurs.

Unhandled Exception code 0xc0000005 at 0x800464d22
base	-erro
0x804748000 - 0x800464d22 = 0x42E32DE
0x42E32DE - 0x0C00000 = 0x36E32DE

0x36E32DE is inside function FUN_036e31f0
This function interprets a text segment and applies visual formatting (colors and underlining) before sending it to the output.

My hypothesis is the absence of files like fonts, similar to Bloodborne...

`??? debugmenulayoutlist.xmllist ???`