### PR TITLE
Journey resolution patch

### DIFF
--- a/PATCHES/Journey.xml
+++ b/PATCHES/Journey.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA00694</ID>
+    </TitleID>
+    <Metadata Title="Journey" Name="Resolution 640×360" Author="Toccata" PatchVer="1.0" AppVer="01.01" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x1669254" Value="8002000068010000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Journey" Name="Resolution 1280×720" Author="Toccata" PatchVer="1.0" AppVer="01.01" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x1669254" Value="00050000d0020000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Journey" Name="Resolution 1600×900" Author="Toccata" PatchVer="1.0" AppVer="01.01" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x1669254" Value="4006000084030000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Journey" Name="Resolution 2560×1440" Author="Toccata" PatchVer="1.0" AppVer="01.01" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x1669254" Value="000a0000a0050000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Journey" Name="Resolution 3840x2160" Author="Toccata" PatchVer="1.0" AppVer="01.01" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x1669254" Value="000f000070080000"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
I found this patch by following this procedure:
1) load the eboot.bin in Ghidra with an offset (options when importing) of 0x400000
2) Analyze the eboot.bin 
3) Search>Memory: 
80 07 00 00 38 04 00 00
(1920 1080)
4) Test the few possibilities by creating an xml patch (replacing by 8002000068010000 for 640x360 which is very visible)
Ctrl+F10 doesn't always reflect the change in resolution. But, you can clearly see the difference by testing with 640x360.
My main source of inspiration was the patch for DarkSOuls3-Orbis by DanielSvoboda. So a big thank you to Daniel.