### PR TITLE
Yoku's Island Express resolution patch

### DIFF
--- a/PATCHES/YokusIslandExpress.xml
+++ b/PATCHES/YokusIslandExpress.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA10650</ID>
+    </TitleID>
+    <Metadata Title="Yoku's Island Express" Name="Resolution 640×360" Author="Toccata" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x004bef22" Value="8002000068010000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Yoku's Island Express" Name="Resolution 1280x720" Author="Toccata" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x004bef22" Value="00050000d0020000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Yoku's Island Express" Name="Resolution 2560x1440" Author="Toccata" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x004bef22" Value="000a0000a0050000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Yoku's Island Express" Name="Resolution 3840x2160" Author="Toccata" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x004bef22" Value="000f000070080000"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
I found this patch by following this procedure:
1) load the eboot.bin in Ghidra with an offset (options when importing) of 0x400000
2) Analyze the eboot.bin 
3) Search>Memory: 
80 07 00 00 38 04 00 00
(1920 1080)
4) Test the few possibilities by creating an xml patch (replacing by 8002000068010000 for 640x360 which is very visible)
Ctrl+F10 doesn't always reflect the change in resolution. But, you can clearly see the difference by testing with 640x360.
The difference in 4k on this game is subtle but many elements have less jaggy edges, which is nice.