### PR TITLE
Geometry Wars Dimensions: resolution patch

### DIFF
--- a/PATCHES/GeometryWarsDimensions.xml
+++ b/PATCHES/GeometryWarsDimensions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA00755</ID>
+    </TitleID>
+    <Metadata Title="Geometry Wars³: Dimensions" Name="Resolution 640x360" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x5d3500" Value="8002"/>
+            <Line Type="bytes" Address="0x5d350d" Value="6801"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Geometry Wars³: Dimensions" Name="Resolution 1280x720" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x5d3500" Value="0005"/>
+            <Line Type="bytes" Address="0x5d350d" Value="d002"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Geometry Wars³: Dimensions" Name="Resolution 2560x1440" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x5d3500" Value="000a"/>
+            <Line Type="bytes" Address="0x5d350d" Value="a005"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Geometry Wars³: Dimensions" Name="Resolution 3840x2160" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x5d3500" Value="000f"/>
+            <Line Type="bytes" Address="0x5d350d" Value="7008"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
I found this patch by following this procedure:
1) load the eboot.bin in Ghidra with an offset (options when importing) of 0x400000
2) Analyze the eboot.bin 
3) Search>Scalars (because Search>Memory: 80 07 00 00 38 04 00 00 didn't bring anything interesting): 0x780 or 0x438
4) When I found 2 values 0x780 and 0x438 which were near, I tried to modify both in an xml patch file.

Ctrl+F10 reflect the change in resolution and for this game, I really see a difference in 4k because it relies very much on thin lines at different angles.