### PR TITLE
Natsuki Chronicles Resolution Patch

### DIFF
--- a/PATCHES/NatsukiChronicles.xml
+++ b/PATCHES/NatsukiChronicles.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA26073</ID>
+    </TitleID>
+    <Metadata Title="Natsuki Chronicles" Name="Resolution 640×360" Author="Toccata" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x00e498a0" Value="8002000068010000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Natsuki Chronicles" Name="Resolution 1280x720" Author="Toccata" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x00e498a0" Value="00050000d0020000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Natsuki Chronicles" Name="Resolution 2560x1440" Author="Toccata" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x00e498a0" Value="000a0000a0050000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Natsuki Chronicles" Name="Resolution 3840x2160" Author="Toccata" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x00e498a0" Value="000f000070080000"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
I found this patch by following this procedure:
1) load the eboot.bin in Ghidra with an offset (options when importing) of 0x400000
2) Analyze the eboot.bin 
3) Search>Memory: 
80 07 00 00 38 04 00 00
4) Create the xml patch
Ctrl+F10 reflects the change in resolution and for this game, I really see a slight improvement in 4k.