### PR TITLE
Windjammers2 resolution patch

### DIFF
--- a/PATCHES/Windjammers2.xml
+++ b/PATCHES/Windjammers2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA15640</ID>
+    </TitleID>
+    <Metadata Title="Windjammers 2" Name="Resolution 640×360" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x407b79" Value="8002000068010000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Windjammers 2" Name="Resolution 1280x720" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x407b79" Value="00050000d0020000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Windjammers 2" Name="Resolution 2560x1440" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x407b79" Value="000a0000a0050000"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Windjammers 2" Name="Resolution 3840x2160" Author="Toccata" PatchVer="1.0" AppVer="01.03" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x407b79" Value="000f000070080000"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
I found this patch by following this procedure:
1) load the eboot.bin in Ghidra with an offset (options when importing) of 0x400000
2) Analyze the eboot.bin
3) Search>Memory:
80 07 00 00 38 04 00 00
4) Create the xml patch
Ctrl+F10 reflects the change in resolution.
The effect of increasing resolution to 4k is subtle: text is a bit sharper. Slight artifact in the splash screens with a very slight black border around the images. It doesn't hurt performance, so a nice little improvement.
