### PR TITLE
Update Bloodborne.xml

### DIFF
--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -3217,7 +3217,7 @@
 		      PatchVer="1.0"
 		      AppVer="01.09"
 		      AppElf="eboot.bin"
-		      isEnabled="true">
+		      isEnabled="false">
         <PatchList>
             <Line Type="bytes" Address="0x01d398b1" Value="eb26909090909090"/>
         </PatchList>

--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -3210,4 +3210,16 @@
             <Line Type="bytes32" Address="0x04CF9AE4" Value="0x3EC00000"/>
         </PatchList>
     </Metadata>
+	<Metadata Title="Bloodborne"
+			  Name="Auto-Refill From Storage on Any Area Refresh/Reload"
+		      Note="Automatically replenishes eligible consumables from your storage whenever any area is refreshed/reloaded. Lowers your storage inventory the same as the vanilla game, without requiring you to die or return to the Hunter's Dream every time. Uses Bloodborne's native auto-refill-from-storage system. NO free items--just a QoL patch."
+		      Author="johnnycoax"
+		      PatchVer="1.0"
+		      AppVer="01.09"
+		      AppElf="eboot.bin"
+		      isEnabled="true">
+        <PatchList>
+            <Line Type="bytes" Address="0x01d398b1" Value="eb26909090909090"/>
+        </PatchList>
+    </Metadata>
 </Patch>

--- a/PATCHES/Bloodborne.xml
+++ b/PATCHES/Bloodborne.xml
@@ -1453,6 +1453,17 @@
             <Line Type="bytes" Address="0X04D27714" Value="9A99993F"/>
         </PatchList>
     </Metadata>
+	<Metadata Title="Bloodborne"
+			  Name="Auto-Refill From Storage on Any Area Refresh/Reload"
+		      Note="Automatically replenishes eligible consumables from your storage whenever any area is refreshed/reloaded. Lowers your storage inventory the same as the vanilla game, without requiring you to die or return to the Hunter's Dream every time. Uses Bloodborne's native auto-refill-from-storage system. NO free items--just a QoL patch."
+		      Author="johnnycoax"
+		      PatchVer="1.0"
+		      AppVer="01.09"
+		      AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01d398b1" Value="eb26909090909090"/>
+        </PatchList>
+    </Metadata>
     <Metadata Title="Bloodborne"
               Name="Unlock Game Region"
               Note="Unlocks the game region to support additional language options, Doesn't switch the X and Circle buttons"
@@ -3208,18 +3219,6 @@
             <Line Type="bytes32" Address="0x04CF9AD0" Value="0x3F000000"/>
             <Line Type="bytes32" Address="0x04CF9AE0" Value="0x3F000000"/>
             <Line Type="bytes32" Address="0x04CF9AE4" Value="0x3EC00000"/>
-        </PatchList>
-    </Metadata>
-	<Metadata Title="Bloodborne"
-			  Name="Auto-Refill From Storage on Any Area Refresh/Reload"
-		      Note="Automatically replenishes eligible consumables from your storage whenever any area is refreshed/reloaded. Lowers your storage inventory the same as the vanilla game, without requiring you to die or return to the Hunter's Dream every time. Uses Bloodborne's native auto-refill-from-storage system. NO free items--just a QoL patch."
-		      Author="johnnycoax"
-		      PatchVer="1.0"
-		      AppVer="01.09"
-		      AppElf="eboot.bin"
-		      isEnabled="false">
-        <PatchList>
-            <Line Type="bytes" Address="0x01d398b1" Value="eb26909090909090"/>
         </PatchList>
     </Metadata>
 </Patch>


### PR DESCRIPTION
added patch that automatically replenishes eligible consumables from your storage whenever any area is refreshed/reloaded. Lowers your storage inventory the same as the vanilla game, without requiring you to die or return to the Hunter's Dream every time. Uses Bloodborne's native auto-refill-from-storage system. NO free items--just a QoL patch.

not sure if its more of a cheat or a patch but i like patch because its technically not giving any extra items to you, its pure QoL