### PR TITLE
Add God of War III Remastered 480p, 720p, 1440p, 2160p and 120 FPS patches

### DIFF
--- a/PATCHES/God_of_War_III_Remastered.xml
+++ b/PATCHES/God_of_War_III_Remastered.xml
@@ -33,8 +33,9 @@
         </PatchList>
     </Metadata>
 
-    <Metadata Title="God of War III Remastered" Name="120 FPS (Correct Delta Time)" Note="Raises the engine maximum framerate from 59.94 to 120 FPS so the frametime clamp produces a 1/120 second gameplay delta. Requires the title specific shadPS4 VBlank frequency to be set to 120. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+    <Metadata Title="God of War III Remastered" Name="120 FPS (Correct Delta Time)" Note="Raises the engine maximum framerate from 59.94 to 120 FPS so the frametime clamp produces a 1/120 second gameplay delta. Correct swing energy calculations matching the original 60 Hz simulation. Requires the title specific shadPS4 VBlank frequency to be set to 120. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.1" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
         <PatchList>
+            <Line Type="bytes" Address="0x0048ff0a" Value="488d05e7c22600"/>
             <Line Type="bytes" Address="0x0075dd04" Value="0000f042"/>
         </PatchList>
     </Metadata>

--- a/PATCHES/God_of_War_III_Remastered.xml
+++ b/PATCHES/God_of_War_III_Remastered.xml
@@ -5,7 +5,7 @@
         <ID>CUSA01715</ID>
     </TitleID>
 
-    <Metadata Title="God of War III Remastered" Name="Resolution Patch (2560x1440)" Note="Forces the base PS4 internal render target hierarchy and output resolution to 2560x1440 without enabling PS4 Pro/Neo mode. Expands the fixed video arena by 512 MiB. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+    <Metadata Title="God of War III Remastered" Name="Resolution Patch (2560x1440)" Note="Forces the base PS4 internal render target hierarchy and output resolution to 2560x1440 without enabling PS4 Pro/Neo mode. Expands the fixed video arena by 512 MiB. Set Additional DMem Allocation to at least 2000, lower values have not been tested. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
         <PatchList>
             <Line Type="bytes" Address="0x005f0c5b" Value="000a0000"/>
             <Line Type="bytes" Address="0x005f0c63" Value="a0050000"/>

--- a/PATCHES/God_of_War_III_Remastered.xml
+++ b/PATCHES/God_of_War_III_Remastered.xml
@@ -5,7 +5,7 @@
         <ID>CUSA01715</ID>
     </TitleID>
 
-    <Metadata Title="God of War III Remastered" Name="Resolution Patch (2560x1440)" Note="Forces the base PS4 internal render-target hierarchy and output resolution to 2560x1440 without enabling PS4 Pro/Neo mode. Expands the fixed video arena by 512 MiB. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+    <Metadata Title="God of War III Remastered" Name="Resolution Patch (2560x1440)" Note="Forces the base PS4 internal render target hierarchy and output resolution to 2560x1440 without enabling PS4 Pro/Neo mode. Expands the fixed video arena by 512 MiB. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
         <PatchList>
             <Line Type="bytes" Address="0x005f0c5b" Value="000a0000"/>
             <Line Type="bytes" Address="0x005f0c63" Value="a0050000"/>
@@ -19,7 +19,7 @@
         </PatchList>
     </Metadata>
 
-    <Metadata Title="God of War III Remastered" Name="120 FPS (Correct Delta Time)" Note="Raises the engine maximum framerate from 59.94 to 120 FPS so the frametime clamp produces a 1/120-second gameplay delta. Requires the title-specific shadPS4 VBlank frequency to be set to 120. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+    <Metadata Title="God of War III Remastered" Name="120 FPS (Correct Delta Time)" Note="Raises the engine maximum framerate from 59.94 to 120 FPS so the frametime clamp produces a 1/120 second gameplay delta. Requires the title specific shadPS4 VBlank frequency to be set to 120. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
         <PatchList>
             <Line Type="bytes" Address="0x0075dd04" Value="0000f042"/>
         </PatchList>

--- a/PATCHES/God_of_War_III_Remastered.xml
+++ b/PATCHES/God_of_War_III_Remastered.xml
@@ -1,8 +1,29 @@
 <?xml version="1.0"?>
 <Patch>
     <TitleID>
+        <ID>CUSA01623</ID>
         <ID>CUSA01715</ID>
     </TitleID>
+
+    <Metadata Title="God of War III Remastered" Name="Resolution Patch (2560x1440)" Note="Forces the base PS4 internal render-target hierarchy and output resolution to 2560x1440 without enabling PS4 Pro/Neo mode. Expands the fixed video arena by 512 MiB. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x005f0c5b" Value="000a0000"/>
+            <Line Type="bytes" Address="0x005f0c63" Value="a0050000"/>
+            <Line Type="bytes" Address="0x005f0c6c" Value="000a"/>
+            <Line Type="bytes" Address="0x005f0c73" Value="a005"/>
+            <Line Type="bytes" Address="0x005643e3" Value="a0050000"/>
+            <Line Type="bytes" Address="0x005643f0" Value="000a0000"/>
+            <Line Type="bytes" Address="0x005ff889" Value="000a0000"/>
+            <Line Type="bytes" Address="0x005ff88f" Value="a0050000"/>
+            <Line Type="bytes" Address="0x007cd918" Value="00000070"/>
+        </PatchList>
+    </Metadata>
+
+    <Metadata Title="God of War III Remastered" Name="120 FPS (Correct Delta Time)" Note="Raises the engine maximum framerate from 59.94 to 120 FPS so the frametime clamp produces a 1/120-second gameplay delta. Requires the title-specific shadPS4 VBlank frequency to be set to 120. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x0075dd04" Value="0000f042"/>
+        </PatchList>
+    </Metadata>
 
     <Metadata Title="God of War III Remastered" Name="Skip Intro" Note="Skips the initial logos. Thanks to illusion0001 aka illusionyy for the PS3 patch which made this very easy." Author="cuesta4" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
         <PatchList>

--- a/PATCHES/God_of_War_III_Remastered.xml
+++ b/PATCHES/God_of_War_III_Remastered.xml
@@ -19,6 +19,20 @@
         </PatchList>
     </Metadata>
 
+    <Metadata Title="God of War III Remastered" Name="Resolution Patch (3840x2160)" Note="Forces the base PS4 internal render target hierarchy and output resolution to 3840x2160 without enabling PS4 Pro/Neo mode. Expands the fixed video arena to 3.25 GiB. Set Additional DMem Allocation to at least 4000, lower values have not been tested. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x005f0c5b" Value="000f0000"/>
+            <Line Type="bytes" Address="0x005f0c63" Value="70080000"/>
+            <Line Type="bytes" Address="0x005f0c6c" Value="000f"/>
+            <Line Type="bytes" Address="0x005f0c73" Value="7008"/>
+            <Line Type="bytes" Address="0x005643e3" Value="70080000"/>
+            <Line Type="bytes" Address="0x005643f0" Value="000f0000"/>
+            <Line Type="bytes" Address="0x005ff889" Value="000f0000"/>
+            <Line Type="bytes" Address="0x005ff88f" Value="70080000"/>
+            <Line Type="bytes" Address="0x007cd918" Value="000000d0"/>
+        </PatchList>
+    </Metadata>
+
     <Metadata Title="God of War III Remastered" Name="120 FPS (Correct Delta Time)" Note="Raises the engine maximum framerate from 59.94 to 120 FPS so the frametime clamp produces a 1/120 second gameplay delta. Requires the title specific shadPS4 VBlank frequency to be set to 120. Verified on CUSA01623 v01.02." Author="kvicken" PatchVer="1.0" AppVer="01.02" AppElf="eboot.bin" isEnabled="false">
         <PatchList>
             <Line Type="bytes" Address="0x0075dd04" Value="0000f042"/>


### PR DESCRIPTION
Add CUSA01623 support for God of War III Remastered v01.02
Add a base PS4 854×480 internal resolution patch
Add a base PS4 1280×720 internal resolution patch
Add a base PS4 2560×1440 internal resolution patch
Add a base PS4 3840×2160 internal resolution patch
Add a separate 120 FPS patch with corrected 1/120 second delta time

Tested on CUSA01623 v01.02 using shadPS4 v0.18.1 WIP revision 7fb1a53

1440p:
<img width="2559" height="1439" alt="1440p" src="https://github.com/user-attachments/assets/93c15f9f-ac0c-417b-b0f9-4b83c7571fde" />

4k:
<img width="3840" height="2160" alt="CUSA01623_20260827_182307_639_game_000007" src="https://github.com/user-attachments/assets/45e560d7-95e5-4bf8-be22-a5b1861aa1db" />

120fps:
[120fps.webm](https://github.com/user-attachments/assets/a426a48f-f841-47b7-8d29-9df094cde650)

