### PR TITLE
Gran Turismo Sport 1.69 - Boot crash fix

### DIFF
--- a/PATCHES/GranTurismoSport.xml
+++ b/PATCHES/GranTurismoSport.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA02168</ID>
+    </TitleID>
+    <Metadata Title="Gran Turismo SPORT" Name="Fix 1.69 update boot crash" Note="Fixes the boot-time ADHOC nil error by delaying boot init 5s so BootSequenceDone fires after ProductBootScreen is ready." Author="Kravickas" PatchVer="1.0" AppVer="01.69" AppElf="eboot.bin" isEnabled="false">
+        <PatchList>
+            <Line Type="bytes" Address="0x0211ab30" Value="e92ba3490090"/>
+            <Line Type="bytes" Address="0x025b4e60" Value="505756525141504151bf404b4c00ff15845e7b0041594158595a5e5f58ff25256f7b00"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
During boot the game sends BootSequenceDone before ProductBootScreen has registered a listener for it. The signal is a one-way latch, so a listener registered afterwards is dispatched immediately, and the handler reads a variable its own setup code has not yet created. This raises an ADHOC nil error, and the game's error dialog then dereferences a null pointer.

The patch delays a single savedata call during boot by 5 seconds, allowing ProductBootScreen to register before the signal is sent.

<img width="1282" height="752" alt="obrazek" src="https://github.com/user-attachments/assets/3340b691-79f1-45d8-ab59-4ce6f0c59972" />
